### PR TITLE
[BE] CI/CD 파이프라인 구축 #2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
             export GITHUB_REPOSITORY=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
             export DB_PASSWORD=${{ secrets.DB_PASSWORD }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,7 +69,9 @@ jobs:
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
             export GITHUB_REPOSITORY=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
-            export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            export DB_URL="${{ secrets.DB_URL }}"
+            export DB_USERNAME="${{ secrets.DB_USERNAME }}"
+            export DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
 
             cd ~/app
             docker compose -f docker-compose.prod.yml pull app

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,90 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image name (lowercase)
+        run: echo "IMAGE_NAME=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Copy docker-compose to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: docker-compose.prod.yml
+          target: ~/app
+
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+            export GITHUB_REPOSITORY=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
+            export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+
+            cd ~/app
+            docker compose -f docker-compose.prod.yml pull app
+            docker compose -f docker-compose.prod.yml up -d
+
+            # Health check — fail the workflow if the app never becomes healthy
+            echo "Waiting for application to start..."
+            for i in $(seq 1 30); do
+              if curl -sf http://localhost:8080/actuator/health > /dev/null 2>&1; then
+                echo "Application is healthy!"
+                exit 0
+              fi
+              sleep 5
+            done
+
+            echo "ERROR: Health check failed after 150 seconds."
+            docker compose -f docker-compose.prod.yml logs app --tail 50
+            exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         run: ./gradlew test
 
       - name: Docker build check
-        run: docker build . --no-cache
+        run: docker build .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Spotless check
+        run: ./gradlew spotlessCheck
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Docker build check
+        run: docker build . --no-cache

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
   release-please:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,21 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Release Please
+        uses: googleapis/release-please-action@v4
+        with:
+          release-type: simple
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 logs/
 
 # Application config (secrets)
+application-local.yml
 application-secret.yml
 **/secret*.yml
 *.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ COPY gradlew settings.gradle build.gradle ./
 COPY gradle ./gradle
 RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
 
-# 소스 복사 및 빌드
+# 소스 복사 및 빌드 (루트 프로젝트만)
 COPY src ./src
-RUN ./gradlew build -x test --no-daemon
+COPY poc ./poc
+RUN ./gradlew :build -x test --no-daemon
 
 # Stage 2: Runtime
 FROM eclipse-temurin:21-jre

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Stage 1: Build
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /app
+
+# Gradle 래퍼 및 설정 파일 복사 (의존성 캐시 레이어)
+COPY gradlew settings.gradle build.gradle ./
+COPY gradle ./gradle
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
+
+# 소스 복사 및 빌드
+COPY src ./src
+RUN ./gradlew build -x test --no-daemon
+
+# Stage 2: Runtime
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,54 @@
+services:
+  app:
+    image: ghcr.io/${GITHUB_REPOSITORY}:latest
+    container_name: webbb-app
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DB_HOST: mysql
+      DB_PORT: 3306
+      DB_NAME: webbb
+      DB_USERNAME: webbb
+      DB_PASSWORD: ${DB_PASSWORD}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  mysql:
+    image: mysql:8.0
+    container_name: webbb-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: webbb
+      MYSQL_USER: webbb
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7.0
+    container_name: webbb-redis
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  mysql-data:
+  redis-data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,35 +6,14 @@ services:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: prod
-      DB_HOST: mysql
-      DB_PORT: 3306
-      DB_NAME: webbb
-      DB_USERNAME: webbb
+      DB_URL: ${DB_URL}
+      DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: redis
       REDIS_PORT: 6379
     depends_on:
-      mysql:
-        condition: service_healthy
       redis:
         condition: service_healthy
-    restart: unless-stopped
-
-  mysql:
-    image: mysql:8.0
-    container_name: webbb-mysql
-    environment:
-      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-      MYSQL_DATABASE: webbb
-      MYSQL_USER: webbb
-      MYSQL_PASSWORD: ${DB_PASSWORD}
-    volumes:
-      - mysql-data:/var/lib/mysql
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_PASSWORD}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
     restart: unless-stopped
 
   redis:
@@ -50,5 +29,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  mysql-data:
   redis-data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -31,7 +31,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_PASSWORD}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -117,11 +117,11 @@ Stage 2 (실행)    eclipse-temurin:21-jre  →  JAR만 복사해서 실행
 | 서비스 | 이미지 | 역할 | 외부 포트 |
 |---|---|---|---|
 | app | GHCR에서 pull | Spring Boot 애플리케이션 | 8080 |
-| mysql | mysql:8.0 | 데이터베이스 | 없음 (내부 전용) |
 | redis | redis:7.0 | 캐시/세션 저장소 | 없음 (내부 전용) |
 
-- app은 mysql, redis가 healthy 상태일 때만 시작 (`depends_on` + `healthcheck`)
-- mysql, redis는 호스트 포트를 노출하지 않음 (Docker 내부 네트워크로만 통신)
+- DB는 AWS RDS(MySQL)를 사용하며, `DB_URL` 환경변수로 JDBC URL 전체를 주입
+- app은 redis가 healthy 상태일 때만 시작 (`depends_on` + `healthcheck`)
+- redis는 호스트 포트를 노출하지 않음 (Docker 내부 네트워크로만 통신)
 - 모든 민감 정보는 환경변수로 주입 (하드코딩 금지)
 
 ### 운영 프로필 (application-prod.yml)
@@ -131,8 +131,8 @@ Stage 2 (실행)    eclipse-temurin:21-jre  →  JAR만 복사해서 실행
 | `ddl-auto` | `validate` | 운영에서 스키마 자동 변경 방지 |
 | `show-sql` | `false` | 운영 로그 노이즈 제거 |
 | `actuator` | `health`만 노출 | CD health check용, 상세 정보 숨김 |
-| `DB_USE_SSL` | 기본값 `false` | Docker 내부 통신 기준. 추후 RDS 등 외부 DB 전환 시 `true` 적용 검토 |
-| DB/Redis 접속 | `${ENV_VAR}` | 환경변수로 주입 |
+| DB 접속 | `${DB_URL}` | RDS JDBC URL 전체를 환경변수로 주입 (SSL 포함) |
+| Redis 접속 | `${REDIS_HOST}`, `${REDIS_PORT}` | 환경변수로 주입 |
 
 ---
 
@@ -145,7 +145,9 @@ Stage 2 (실행)    eclipse-temurin:21-jre  →  JAR만 복사해서 실행
 | `EC2_HOST` | EC2 퍼블릭 IP | `3.35.xxx.xxx` |
 | `EC2_USER` | SSH 유저 | `ec2-user` |
 | `EC2_SSH_KEY` | SSH 프라이빗 키 (PEM 전체 내용) | `-----BEGIN RSA...` |
-| `DB_PASSWORD` | MySQL 운영 비밀번호 | - |
+| `DB_URL` | RDS JDBC URL (SSL 포함) | `jdbc:mysql://xxx.rds.amazonaws.com:3306/webbb?useSSL=true&sslMode=REQUIRED...` |
+| `DB_USERNAME` | RDS 유저명 | `admin` |
+| `DB_PASSWORD` | RDS 비밀번호 | - |
 | `GHCR_TOKEN` | GHCR 접근용 PAT (public 레포 기준 `read:packages` 권한) | `ghp_xxxx` |
 | `GHCR_USERNAME` | GHCR 로그인용 GitHub 계정명 (GHCR_TOKEN 발급 계정과 동일해야 함) | `my-github-id` |
 
@@ -207,5 +209,5 @@ mkdir -p ~/app
 |---|---|---|
 | GHCR 계정 이관 | 개인 계정 PAT 사용 중 | 팀 공용 계정 준비 시 `GHCR_TOKEN` + `GHCR_USERNAME` 동시 교체 |
 | OIDC + ECR + SSM 전환 | GHCR + SSH 기반 배포 | 운영 안정화 이후 별도 검토 (AWS 자격증명/SSH 키 관리 개선) |
-| DB SSL 적용 | `DB_USE_SSL=false` (Docker 내부 통신) | RDS 등 외부 DB 전환 시 `true` 적용 |
+| DB SSL 적용 | RDS `sslMode=REQUIRED` 적용 완료 | - |
 | CI 검증 강화 | spotless + test + docker build | 도메인 로직/테스트가 늘어나면 점진적으로 강화 |

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,0 +1,193 @@
+# CI/CD 파이프라인 가이드
+
+## 전체 흐름
+
+```
+feat/xxx 브랜치 작업
+    │
+    ▼
+PR to main ──→ CI (spotless + test + docker build check)
+    │                ❌ 실패 → 머지 차단
+    ▼                ✅ 통과
+main에 머지 ──→ CD (build → GHCR push → EC2 배포 → health check)
+    │                ❌ health check 실패 → 워크플로우 실패 처리
+    ├──→ Release Please → Release PR 자동 생성
+    │
+    ▼
+Release PR 머지 ──→ GitHub Release + 태그 + CHANGELOG 자동 업데이트
+```
+
+---
+
+## 워크플로우 상세
+
+### 1. CI — `.github/workflows/ci.yml`
+
+| 항목 | 값 |
+|---|---|
+| 트리거 | `main` 브랜치로 PR이 열릴 때 |
+| 목적 | 코드 품질 검증 (머지 전 게이트) |
+
+**실행 단계:**
+
+1. **Spotless check** — Google Java Format 규칙에 맞는지 검사. 포맷이 안 맞으면 실패
+2. **Gradle test** — 테스트 실행 (현재는 부트 기동 테스트 수준이므로, 도메인 로직이 추가되면 테스트도 함께 보강 필요)
+3. **Docker build check** — Dockerfile이 정상 빌드되는지 확인 (이미지 push는 안 함)
+
+> GitHub 레포 Settings > Branches > Branch protection rules에서
+> `main` 브랜치에 "Require status checks to pass before merging"을 설정하면
+> CI가 통과해야만 머지할 수 있습니다.
+
+---
+
+### 2. CD — `.github/workflows/cd.yml`
+
+| 항목 | 값 |
+|---|---|
+| 트리거 | `main` 브랜치에 push (= PR 머지) |
+| 목적 | 서버 자동 배포 |
+
+**실행 단계:**
+
+1. **이미지 이름 소문자 변환** — GHCR은 대문자를 허용하지 않으므로 `github.repository`를 소문자로 변환
+2. **테스트 재실행** — 머지 후 최종 검증
+3. **Docker 이미지 빌드 & GHCR push** — 두 개 태그로 push
+   - `latest` — 항상 최신 빌드를 가리킴
+   - `<commit-sha>` — 특정 커밋으로 롤백할 때 사용
+4. **SCP로 compose 파일 전송** — EC2의 `~/app`에 최신 `docker-compose.prod.yml` 배치
+5. **SSH 접속 후 배포** — `docker compose pull` → `up -d`로 컨테이너 교체
+6. **Health check** — 최대 150초(5초 × 30회) 대기하며 `/actuator/health` 확인
+   - 성공 시 `exit 0` → 워크플로우 성공
+   - 실패 시 앱 로그 출력 후 `exit 1` → **워크플로우 실패 처리**
+
+---
+
+### 3. Release Please — `.github/workflows/release-please.yml`
+
+| 항목 | 값 |
+|---|---|
+| 트리거 | `main` 브랜치에 push (= PR 머지) |
+| 목적 | 버전 관리 및 릴리즈 자동화 |
+
+**동작 방식:**
+
+1. main에 push가 오면 커밋 메시지를 분석해서 **Release PR을 자동 생성/갱신**
+2. Release PR에는 `CHANGELOG.md` 생성/업데이트와 `version.txt` 버전 범프가 포함될 수 있음
+   - 현재 `release-type: simple` 설정이며, 별도 config 파일(`release-please-config.json` 등)은 없음
+   - 첫 릴리즈 시 Release Please가 이 파일들을 자동 생성함
+3. Release PR을 머지하면 **GitHub Release + Git 태그**가 자동 생성
+
+---
+
+## Conventional Commits 규칙
+
+Release Please가 버전을 자동으로 올리려면 커밋 메시지가 아래 형식을 따라야 합니다.
+
+| 접두사 | 의미 | 버전 변경 | 예시 |
+|---|---|---|---|
+| `feat:` | 새 기능 | Minor (0.**1**.0) | `feat: 소셜 로그인 추가` |
+| `fix:` | 버그 수정 | Patch (0.0.**1**) | `fix: 토큰 만료 시 NPE 수정` |
+| `feat!:` | 호환성 깨는 변경 | Major (**1**.0.0) | `feat!: API 응답 구조 변경` |
+| `docs:` | 문서 | 변경 없음 | `docs: README 업데이트` |
+| `chore:` | 빌드/설정 | 변경 없음 | `chore: CI 워크플로우 추가` |
+| `ci:` | CI 변경 | 변경 없음 | `ci: Spotless 체크 추가` |
+| `refactor:` | 리팩토링 | 변경 없음 | `refactor: 서비스 레이어 분리` |
+| `test:` | 테스트 | 변경 없음 | `test: 유저 서비스 테스트 추가` |
+
+> `docs:`, `chore:`, `ci:` 등은 릴리즈에 포함되지 않습니다.
+> `feat:` 또는 `fix:`가 하나 이상 있어야 Release PR이 생성됩니다.
+
+---
+
+## 인프라 구성
+
+### Docker 이미지 (Dockerfile)
+
+Multi-stage 빌드로 최종 이미지 크기를 최소화합니다.
+
+```
+Stage 1 (빌드)    eclipse-temurin:21-jdk  →  Gradle 빌드, JAR 생성
+Stage 2 (실행)    eclipse-temurin:21-jre  →  JAR만 복사해서 실행
+```
+
+의존성 레이어를 분리하여 소스 코드만 변경되었을 때 Gradle 의존성 다운로드를 캐시합니다.
+
+### 운영 Compose (docker-compose.prod.yml)
+
+| 서비스 | 이미지 | 역할 | 외부 포트 |
+|---|---|---|---|
+| app | GHCR에서 pull | Spring Boot 애플리케이션 | 8080 |
+| mysql | mysql:8.0 | 데이터베이스 | 없음 (내부 전용) |
+| redis | redis:7.0 | 캐시/세션 저장소 | 없음 (내부 전용) |
+
+- app은 mysql, redis가 healthy 상태일 때만 시작 (`depends_on` + `healthcheck`)
+- mysql, redis는 호스트 포트를 노출하지 않음 (Docker 내부 네트워크로만 통신)
+- 모든 민감 정보는 환경변수로 주입 (하드코딩 금지)
+
+### 운영 프로필 (application-prod.yml)
+
+| 설정 | 값 | 이유 |
+|---|---|---|
+| `ddl-auto` | `validate` | 운영에서 스키마 자동 변경 방지 |
+| `show-sql` | `false` | 운영 로그 노이즈 제거 |
+| `actuator` | `health`만 노출 | CD health check용, 상세 정보 숨김 |
+| DB/Redis 접속 | `${ENV_VAR}` | 환경변수로 주입 |
+
+---
+
+## GitHub Secrets 설정
+
+레포 Settings > Secrets and variables > Actions에서 아래 값을 등록해야 합니다.
+
+| Secret | 용도 | 예시 값 |
+|---|---|---|
+| `EC2_HOST` | EC2 퍼블릭 IP | `3.35.xxx.xxx` |
+| `EC2_USER` | SSH 유저 | `ec2-user` |
+| `EC2_SSH_KEY` | SSH 프라이빗 키 (PEM 전체 내용) | `-----BEGIN RSA...` |
+| `DB_PASSWORD` | MySQL 운영 비밀번호 | - |
+| `GHCR_TOKEN` | GHCR 접근용 PAT (`read:packages` 권한) | `ghp_xxxx` |
+
+### GHCR_TOKEN 생성 방법
+
+1. GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)
+2. Generate new token
+3. 권한: `read:packages` 체크
+4. 생성된 토큰을 레포 Secrets에 `GHCR_TOKEN`으로 등록
+
+> `GITHUB_TOKEN`은 워크플로우 러너 안에서만 유효합니다.
+> EC2에서 GHCR 이미지를 pull하려면 별도 PAT가 필요합니다.
+
+---
+
+## EC2 사전 준비
+
+배포 대상 EC2에 아래가 설치되어 있어야 합니다.
+
+```bash
+# Docker 설치
+sudo yum install -y docker
+sudo systemctl enable docker && sudo systemctl start docker
+sudo usermod -aG docker ec2-user
+
+# Docker Compose 플러그인 설치
+sudo mkdir -p /usr/local/lib/docker/cli-plugins
+sudo curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 \
+  -o /usr/local/lib/docker/cli-plugins/docker-compose
+sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+# 작업 디렉토리 생성
+mkdir -p ~/app
+```
+
+---
+
+## 관련 파일 목록
+
+| 파일 | 역할 |
+|---|---|
+| `Dockerfile` | 멀티스테이지 Docker 빌드 |
+| `docker-compose.prod.yml` | 운영 배포용 Compose |
+| `src/main/resources/application-prod.yml` | 운영 Spring 프로필 |
+| `.github/workflows/ci.yml` | PR 시 CI 워크플로우 |
+| `.github/workflows/cd.yml` | main push 시 CD 워크플로우 |
+| `.github/workflows/release-please.yml` | main push 시 릴리즈 자동화 |

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -131,6 +131,7 @@ Stage 2 (실행)    eclipse-temurin:21-jre  →  JAR만 복사해서 실행
 | `ddl-auto` | `validate` | 운영에서 스키마 자동 변경 방지 |
 | `show-sql` | `false` | 운영 로그 노이즈 제거 |
 | `actuator` | `health`만 노출 | CD health check용, 상세 정보 숨김 |
+| `DB_USE_SSL` | 기본값 `false` | Docker 내부 통신 기준. 추후 RDS 등 외부 DB 전환 시 `true` 적용 검토 |
 | DB/Redis 접속 | `${ENV_VAR}` | 환경변수로 주입 |
 
 ---
@@ -145,17 +146,23 @@ Stage 2 (실행)    eclipse-temurin:21-jre  →  JAR만 복사해서 실행
 | `EC2_USER` | SSH 유저 | `ec2-user` |
 | `EC2_SSH_KEY` | SSH 프라이빗 키 (PEM 전체 내용) | `-----BEGIN RSA...` |
 | `DB_PASSWORD` | MySQL 운영 비밀번호 | - |
-| `GHCR_TOKEN` | GHCR 접근용 PAT (`read:packages` 권한) | `ghp_xxxx` |
+| `GHCR_TOKEN` | GHCR 접근용 PAT (public 레포 기준 `read:packages` 권한) | `ghp_xxxx` |
+| `GHCR_USERNAME` | GHCR 로그인용 GitHub 계정명 (GHCR_TOKEN 발급 계정과 동일해야 함) | `my-github-id` |
 
-### GHCR_TOKEN 생성 방법
+### GHCR_TOKEN / GHCR_USERNAME 설정 방법
 
 1. GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)
 2. Generate new token
-3. 권한: `read:packages` 체크
+3. 권한: `read:packages` 체크 (현재 레포가 public이므로 이 권한이면 충분)
 4. 생성된 토큰을 레포 Secrets에 `GHCR_TOKEN`으로 등록
+5. 해당 토큰을 발급한 GitHub 계정명을 `GHCR_USERNAME`으로 등록
 
 > `GITHUB_TOKEN`은 워크플로우 러너 안에서만 유효합니다.
 > EC2에서 GHCR 이미지를 pull하려면 별도 PAT가 필요합니다.
+
+> **운영 기준:** 현재는 개인 계정으로 임시 발급하여 사용 중입니다.
+> 추후 팀 공용 계정(또는 봇 계정)으로 이관하여 운영하는 것을 권장합니다.
+> 이관 시 `GHCR_TOKEN`과 `GHCR_USERNAME`을 동시에 교체해야 합니다.
 
 ---
 
@@ -191,3 +198,14 @@ mkdir -p ~/app
 | `.github/workflows/ci.yml` | PR 시 CI 워크플로우 |
 | `.github/workflows/cd.yml` | main push 시 CD 워크플로우 |
 | `.github/workflows/release-please.yml` | main push 시 릴리즈 자동화 |
+
+---
+
+## 후속 개선 과제
+
+| 과제 | 현재 상태 | 전환 시점 |
+|---|---|---|
+| GHCR 계정 이관 | 개인 계정 PAT 사용 중 | 팀 공용 계정 준비 시 `GHCR_TOKEN` + `GHCR_USERNAME` 동시 교체 |
+| OIDC + ECR + SSM 전환 | GHCR + SSH 기반 배포 | 운영 안정화 이후 별도 검토 (AWS 자격증명/SSH 키 관리 개선) |
+| DB SSL 적용 | `DB_USE_SSL=false` (Docker 내부 통신) | RDS 등 외부 DB 전환 시 `true` 적용 |
+| CI 검증 강화 | spotless + test + docker build | 도메인 로직/테스트가 늘어나면 점진적으로 강화 |

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,7 +5,25 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: false
+    show-sql: false
+
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  profiles:
+    active: test
+
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## PR 제목(내용 요약)
[BE] CI/CD 파이프라인 구축 + RDS 연동

## 📌 변경 내용 & 이유
- CI 워크플로우 추가 (spotless + test + docker build check) — PR 머지 전 코드 품질 게이트
- CD 워크플로우 추가 (GHCR push + EC2 배포 + health check) — main 머지 시 자동 배포
- Release Please 워크플로우 추가 — 버전 관리 및 릴리즈 자동화
- Dockerfile 멀티스테이지 빌드 구성 — 빌드/실행 분리로 이미지 경량화
- docker-compose.prod.yml 운영 배포 구성 — app + redis (DB는 RDS 사용)
- application-prod.yml 운영 프로필 추가 — RDS 연결 (`DB_URL` 환경변수)
- Docker MySQL 제거, AWS RDS(MySQL) 전환 — SSL 적용 (`sslMode=REQUIRED`)
- Actuator 의존성 추가 — CD health check 엔드포인트용
- docs/cicd.md 파이프라인 가이드 문서 작성

## 🧪 테스트 방법
- `./gradlew spotlessCheck` — 포맷 검증
- `./gradlew test` — 테스트 실행

## ✅ 검증 완료 항목
- [x] main rebase 충돌 해결 완료
- [x] GitHub Secrets 등록: `DB_URL`, `DB_USERNAME` 추가
- [x] docker-compose.prod.yml에서 MySQL 컨테이너 제거, RDS 환경변수 연결
- [x] cd.yml에서 `DB_URL`, `DB_USERNAME`, `DB_PASSWORD` 전달
- [x] application-prod.yml에서 `${DB_URL}` 단일 환경변수로 통합
- [x] docs/cicd.md RDS 전환 반영

## 📢 논의하고 싶은 내용
- develop 브랜치는 로컬 확인 용도로만 사용하고, CI/CD는 main 브랜치에서만 동작합니다
- DB는 AWS RDS를 사용하며, JDBC URL 전체를 `DB_URL` Secret으로 관리합니다

## 🧩 관련 이슈
Close #2