### PR TITLE
[BE] AI 응원 서비스 PoC 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ application-secret.yml
 # OS
 .DS_Store
 Thumbs.db
+*.swp
 
 # Java
 *.class

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ tasks.withType(JavaCompile).configureEach {
 // Spotless 코드 포맷팅
 spotless {
     java {
-        target 'src/*/java/**/*.java'
+        target 'src/*/java/**/*.java', 'poc/*/src/*/java/**/*.java'
 
         // 불필요한 import 제거
         removeUnusedImports()

--- a/poc/allkite/README.md
+++ b/poc/allkite/README.md
@@ -1,0 +1,39 @@
+# AI 응원 서비스 PoC (janghh)
+
+취준생 심리 케어 AI 서비스 - Claude API 연동
+
+## 실행 방법
+
+### 1. 환경변수 설정
+```bash
+export CLAUDE_API_KEY=your-api-key-here
+```
+
+### 2. build.gradle 의존성 (메인 프로젝트에 추가 시)
+```groovy
+// Spring AI BOM
+dependencyManagement {
+    imports {
+        mavenBom 'org.springframework.ai:spring-ai-bom:1.0.0'
+    }
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+}
+
+// 의존성
+implementation 'org.springframework.ai:spring-ai-starter-model-anthropic'
+```
+
+### 3. application.yml 설정
+```yaml
+spring:
+  ai:
+    anthropic:
+      api-key: ${CLAUDE_API_KEY}
+      chat:
+        options:
+          model: claude-sonnet-4-5-20250929
+```

--- a/poc/allkite/build.gradle
+++ b/poc/allkite/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.dnd'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+}
+
+dependencies {
+    implementation platform('org.springframework.boot:spring-boot-dependencies:3.4.5')
+    implementation platform('org.springframework.ai:spring-ai-bom:1.0.0')
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.ai:spring-ai-starter-model-anthropic'
+
+    testImplementation platform('org.springframework.boot:spring-boot-dependencies:3.4.5')
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/poc/allkite/src/main/java/com/dnd/webbb/ai/application/AiEncouragementService.java
+++ b/poc/allkite/src/main/java/com/dnd/webbb/ai/application/AiEncouragementService.java
@@ -1,0 +1,91 @@
+package com.dnd.webbb.ai.application;
+
+import com.dnd.webbb.ai.application.dto.AnalysisResponse;
+import com.dnd.webbb.ai.application.dto.EncouragementResult;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AiEncouragementService {
+
+    private static final Logger log = LoggerFactory.getLogger(AiEncouragementService.class);
+
+    private static final List<String> CRISIS_KEYWORDS =
+            List.of("죽고 싶", "자해", "자살", "극단적 선택", "삶을 끝내");
+
+    private static final String CRISIS_MESSAGE =
+            "당신의 이야기를 들었습니다. 지금 많이 힘드시죠. "
+                    + "전문 상담사와 이야기를 나눠보시는 건 어떨까요?\n\n"
+                    + "• 자살예방상담전화: 1393 (24시간)\n"
+                    + "• 정신건강위기상담전화: 109 (24시간)";
+
+    private static final String SYSTEM_PROMPT =
+            """
+            너는 취준생 고민 상담 전문가야. 아래 규칙을 반드시 지켜.
+
+            ## 역할
+            - 사용자의 고민글을 읽고 감정을 분석한 뒤, 공감과 응원이 담긴 응답을 생성해.
+
+            ## 가드레일
+            - 공감을 최우선으로 해. 상대의 감정을 먼저 인정해줘.
+            - 다른 사람과 비교하지 마.
+            - "넌 ~해야 해", "~하면 안 돼" 같은 단정적 표현을 쓰지 마.
+            - 훈계하거나 가르치려 들지 마.
+            - 구체적이고 실천 가능한 작은 행동 하나를 제안해.
+
+            ## 출력 형식
+            반드시 아래 JSON 구조로만 응답해:
+            - emotionTags: 감정 태그 리스트 (예: 불안, 번아웃, 자존감저하, 외로움, 막막함 등)
+            - summary: 고민을 한 문장으로 요약
+            - encouragementMessage: 공감과 응원이 담긴 메시지
+            - smallActionTip: 오늘 당장 할 수 있는 작은 행동 1개
+            """;
+
+    private final ChatClient chatClient;
+
+    public AiEncouragementService(ChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+
+    public AnalysisResponse analyze(String text, String tone) {
+        if (containsCrisisSignal(text)) {
+            return new AnalysisResponse(true, List.of(), "", CRISIS_MESSAGE, "");
+        }
+
+        try {
+            String userPrompt =
+                    String.format(
+                            """
+                    말투: %s
+                    고민글: %s
+                    """,
+                            tone, text);
+
+            EncouragementResult result =
+                    chatClient
+                            .prompt()
+                            .system(SYSTEM_PROMPT)
+                            .user(userPrompt)
+                            .call()
+                            .entity(EncouragementResult.class);
+
+            return new AnalysisResponse(
+                    false,
+                    result.emotionTags(),
+                    result.summary(),
+                    result.encouragementMessage(),
+                    result.smallActionTip());
+        } catch (Exception e) {
+            log.error("AI 호출 실패", e);
+            return new AnalysisResponse(
+                    false, List.of(), "", "지금은 응답을 생성하기 어렵습니다. 잠시 후 다시 시도해주세요.", "");
+        }
+    }
+
+    private boolean containsCrisisSignal(String text) {
+        return CRISIS_KEYWORDS.stream().anyMatch(text::contains);
+    }
+}

--- a/poc/allkite/src/main/java/com/dnd/webbb/ai/application/dto/AnalysisResponse.java
+++ b/poc/allkite/src/main/java/com/dnd/webbb/ai/application/dto/AnalysisResponse.java
@@ -1,0 +1,10 @@
+package com.dnd.webbb.ai.application.dto;
+
+import java.util.List;
+
+public record AnalysisResponse(
+        boolean crisisDetected,
+        List<String> emotionTags,
+        String summary,
+        String encouragementMessage,
+        String smallActionTip) {}

--- a/poc/allkite/src/main/java/com/dnd/webbb/ai/application/dto/EncouragementResult.java
+++ b/poc/allkite/src/main/java/com/dnd/webbb/ai/application/dto/EncouragementResult.java
@@ -1,0 +1,9 @@
+package com.dnd.webbb.ai.application.dto;
+
+import java.util.List;
+
+public record EncouragementResult(
+        List<String> emotionTags,
+        String summary,
+        String encouragementMessage,
+        String smallActionTip) {}

--- a/poc/allkite/src/main/java/com/dnd/webbb/ai/config/AiConfig.java
+++ b/poc/allkite/src/main/java/com/dnd/webbb/ai/config/AiConfig.java
@@ -1,0 +1,14 @@
+package com.dnd.webbb.ai.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiConfig {
+
+    @Bean
+    public ChatClient chatClient(ChatClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/poc/allkite/src/main/java/com/dnd/webbb/ai/interfaces/AiController.java
+++ b/poc/allkite/src/main/java/com/dnd/webbb/ai/interfaces/AiController.java
@@ -1,0 +1,28 @@
+package com.dnd.webbb.ai.interfaces;
+
+import com.dnd.webbb.ai.application.AiEncouragementService;
+import com.dnd.webbb.ai.application.dto.AnalysisResponse;
+import com.dnd.webbb.ai.interfaces.dto.AnalyzeRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/ai")
+public class AiController {
+
+    private final AiEncouragementService aiEncouragementService;
+
+    public AiController(AiEncouragementService aiEncouragementService) {
+        this.aiEncouragementService = aiEncouragementService;
+    }
+
+    @PostMapping("/analyze")
+    public ResponseEntity<AnalysisResponse> analyze(@Valid @RequestBody AnalyzeRequest request) {
+        AnalysisResponse result = aiEncouragementService.analyze(request.text(), request.tone());
+        return ResponseEntity.ok(result);
+    }
+}

--- a/poc/allkite/src/main/java/com/dnd/webbb/ai/interfaces/dto/AnalyzeRequest.java
+++ b/poc/allkite/src/main/java/com/dnd/webbb/ai/interfaces/dto/AnalyzeRequest.java
@@ -1,0 +1,12 @@
+package com.dnd.webbb.ai.interfaces.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AnalyzeRequest(@NotBlank(message = "고민글 본문은 필수입니다.") String text, String tone) {
+
+    public AnalyzeRequest {
+        if (tone == null || tone.isBlank()) {
+            tone = "친구같은";
+        }
+    }
+}

--- a/poc/allkite/src/main/resources/application.yml
+++ b/poc/allkite/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  ai:
+    anthropic:
+      api-key: ${CLAUDE_API_KEY}
+      chat:
+        options:
+          model: claude-sonnet-4-5-20250929

--- a/poc/allkite/src/test/java/com/dnd/webbb/ai/application/AiEncouragementServiceIntegrationTest.java
+++ b/poc/allkite/src/test/java/com/dnd/webbb/ai/application/AiEncouragementServiceIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.dnd.webbb.ai.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dnd.webbb.ai.application.dto.AnalysisResponse;
+import com.dnd.webbb.ai.config.AiConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "CLAUDE_API_KEY", matches = ".+")
+class AiEncouragementServiceIntegrationTest {
+
+    @SpringBootApplication(scanBasePackages = "com.dnd.webbb.ai")
+    @Import(AiConfig.class)
+    static class TestApp {}
+
+    @Autowired private AiEncouragementService service;
+
+    @Test
+    void 정상_고민글에_대해_AI_응답을_정상_수신한다() {
+        AnalysisResponse result = service.analyze("면접을 10번이나 떨어졌어. 이제 자신감이 하나도 없어.", "친구같은");
+
+        assertThat(result.crisisDetected()).isFalse();
+        assertThat(result.emotionTags()).isNotEmpty();
+        assertThat(result.summary()).isNotBlank();
+        assertThat(result.encouragementMessage()).isNotBlank();
+        assertThat(result.smallActionTip()).isNotBlank();
+    }
+
+    @Test
+    void 위기_키워드_포함시_AI_호출_없이_안전_안내를_반환한다() {
+        AnalysisResponse result = service.analyze("취업이 안돼서 죽고 싶어", "친구같은");
+
+        assertThat(result.crisisDetected()).isTrue();
+        assertThat(result.encouragementMessage()).contains("1393");
+        assertThat(result.encouragementMessage()).contains("109");
+        assertThat(result.emotionTags()).isEmpty();
+    }
+}

--- a/poc/allkite/src/test/java/com/dnd/webbb/ai/application/AiEncouragementServiceTest.java
+++ b/poc/allkite/src/test/java/com/dnd/webbb/ai/application/AiEncouragementServiceTest.java
@@ -1,0 +1,80 @@
+package com.dnd.webbb.ai.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dnd.webbb.ai.application.dto.AnalysisResponse;
+import com.dnd.webbb.ai.application.dto.EncouragementResult;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClient;
+
+class AiEncouragementServiceTest {
+
+    private ChatClient chatClient;
+    private AiEncouragementService service;
+
+    @BeforeEach
+    void setUp() {
+        chatClient = mock(ChatClient.class);
+        service = new AiEncouragementService(chatClient);
+    }
+
+    @Test
+    void 위기_키워드_감지시_AI_호출_없이_안전_안내를_반환한다() {
+        AnalysisResponse result = service.analyze("취업이 안돼서 죽고 싶어", "친구같은");
+
+        assertThat(result.crisisDetected()).isTrue();
+        assertThat(result.encouragementMessage()).contains("1393");
+        assertThat(result.encouragementMessage()).contains("109");
+        verify(chatClient, never()).prompt();
+    }
+
+    @Test
+    void 자해_키워드도_위기로_감지한다() {
+        AnalysisResponse result = service.analyze("자해하고 싶은 충동이 있어", "친구같은");
+
+        assertThat(result.crisisDetected()).isTrue();
+        assertThat(result.encouragementMessage()).contains("1393");
+    }
+
+    @Test
+    void AI_호출_실패시_fallback_응답을_반환한다() {
+        when(chatClient.prompt()).thenThrow(new RuntimeException("API 연결 실패"));
+
+        AnalysisResponse result = service.analyze("면접에서 떨어졌어", "친구같은");
+
+        assertThat(result.crisisDetected()).isFalse();
+        assertThat(result.encouragementMessage()).contains("잠시 후 다시 시도해주세요");
+        assertThat(result.emotionTags()).isEmpty();
+    }
+
+    @Test
+    void 정상_요청시_AI_응답을_반환한다() {
+        ChatClient.ChatClientRequestSpec requestSpec = mock(ChatClient.ChatClientRequestSpec.class);
+        ChatClient.CallResponseSpec callSpec = mock(ChatClient.CallResponseSpec.class);
+
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.system(any(String.class))).thenReturn(requestSpec);
+        when(requestSpec.user(any(String.class))).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callSpec);
+        when(callSpec.entity(EncouragementResult.class))
+                .thenReturn(
+                        new EncouragementResult(
+                                List.of("불안", "자존감저하"),
+                                "면접 탈락으로 힘들어하고 있다",
+                                "충분히 잘하고 있어",
+                                "오늘 하루 산책하기"));
+
+        AnalysisResponse result = service.analyze("면접에서 떨어졌어", "친구같은");
+
+        assertThat(result.crisisDetected()).isFalse();
+        assertThat(result.emotionTags()).containsExactly("불안", "자존감저하");
+        assertThat(result.encouragementMessage()).isEqualTo("충분히 잘하고 있어");
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'webbb'
+
+include 'poc:allkite'


### PR DESCRIPTION
## PR 제목(내용 요약)
[BE] AI 응원 서비스 PoC 구현

## 📌 변경 내용 & 이유
- Claude API(Anthropic) 기반 취준생 심리 케어 AI 응원 서비스 PoC 구현
- 위험 신호(자해/극단선택) 감지 가드레일 추가 (1393, 109 안내)
- AI 호출 실패 시 fallback 응답 처리
- application → interfaces 역방향 의존 해소 (DTO를 application.dto로 이동)
- poc/allkite 디렉토리로 PoC 분리, Gradle 서브프로젝트로 구성
- Spotless 검사 대상에 poc 디렉토리 포함

## 🧪 테스트 방법
- 단위 테스트 4건: `./gradlew :poc:allkite:test` (위기감지 2건, fallback 1건, 정상응답 1건)
- 통합 테스트 2건: `CLAUDE_API_KEY=<key> ./gradlew :poc:allkite:test` (실제 Claude API 호출)
- 포맷 검증: `./gradlew spotlessCheck`

## ✅ 검증 완료 항목
- [x] `spotlessCheck` 통과
- [x] `:poc:allkite:compileJava` 통과
- [x] `:poc:allkite:test` 단위 테스트 4건 통과
- [x] 통합 테스트 2건 통과 (실제 Claude API 호출로 응답 수신 확인)
- [x] 민감정보(API 키/토큰) 노출 없음 - 환경변수 참조만 사용
- [x] curl로 Claude API 직접 호출 정상 응답 확인

## 📢 논의하고 싶은 내용
- PoC이므로 메인 빌드와 독립적으로 구성했습니다
- API 키는 `CLAUDE_API_KEY` 환경변수로만 참조합니다

## 🧩 관련 이슈
Close #9