### PR TITLE
[BE] feat: ERD 기반 JPA 엔티티 전체 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.iml
 .vscode/
 
+# Worktrees
+.worktrees/
+
 # Local
 CLAUDE.local.md
 .claude/

--- a/src/main/java/com/dnd/webbb/category/domain/BoardCategory.java
+++ b/src/main/java/com/dnd/webbb/category/domain/BoardCategory.java
@@ -1,0 +1,61 @@
+package com.dnd.webbb.category.domain;
+
+import com.dnd.webbb.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "board_category")
+public class BoardCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 200)
+    private String description;
+
+    @Column(nullable = false)
+    private int sortOrder = 0;
+
+    @Column(nullable = false)
+    private boolean isActive = true;
+
+    protected BoardCategory() {}
+
+    public static BoardCategory create(String name, String description, int sortOrder) {
+        BoardCategory category = new BoardCategory();
+        category.name = name;
+        category.description = description;
+        category.sortOrder = sortOrder;
+        category.isActive = true;
+        return category;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public boolean isActive() {
+        return isActive;
+    }
+}

--- a/src/main/java/com/dnd/webbb/comment/domain/Comment.java
+++ b/src/main/java/com/dnd/webbb/comment/domain/Comment.java
@@ -1,0 +1,97 @@
+package com.dnd.webbb.comment.domain;
+
+import com.dnd.webbb.global.common.entity.BaseEntity;
+import com.dnd.webbb.post.domain.Post;
+import com.dnd.webbb.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "comment")
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parent;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private int likeCount = 0;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    protected Comment() {}
+
+    public static Comment create(Post post, User user, Comment parent, String content) {
+        Comment comment = new Comment();
+        comment.post = post;
+        comment.user = user;
+        comment.parent = parent;
+        comment.content = content;
+        return comment;
+    }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Comment getParent() {
+        return parent;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public int getLikeCount() {
+        return likeCount;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+}

--- a/src/main/java/com/dnd/webbb/comment/domain/CommentLike.java
+++ b/src/main/java/com/dnd/webbb/comment/domain/CommentLike.java
@@ -1,0 +1,53 @@
+package com.dnd.webbb.comment.domain;
+
+import com.dnd.webbb.global.common.entity.BaseCreatedEntity;
+import com.dnd.webbb.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+        name = "comment_like",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"comment_id", "user_id"}))
+public class CommentLike extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    protected CommentLike() {}
+
+    public static CommentLike create(Comment comment, User user) {
+        CommentLike commentLike = new CommentLike();
+        commentLike.comment = comment;
+        commentLike.user = user;
+        return commentLike;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Comment getComment() {
+        return comment;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/java/com/dnd/webbb/emotion/domain/EmotionType.java
+++ b/src/main/java/com/dnd/webbb/emotion/domain/EmotionType.java
@@ -1,0 +1,9 @@
+package com.dnd.webbb.emotion.domain;
+
+public enum EmotionType {
+    ANGRY,
+    SAD,
+    TIRED,
+    ANXIOUS,
+    ETC
+}

--- a/src/main/java/com/dnd/webbb/emotion/domain/PostEmotion.java
+++ b/src/main/java/com/dnd/webbb/emotion/domain/PostEmotion.java
@@ -1,0 +1,66 @@
+package com.dnd.webbb.emotion.domain;
+
+import com.dnd.webbb.global.common.entity.BaseCreatedEntity;
+import com.dnd.webbb.post.domain.Post;
+import com.dnd.webbb.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+        name = "post_emotion",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
+public class PostEmotion extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private EmotionType emotionType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    protected PostEmotion() {}
+
+    public static PostEmotion create(Post post, EmotionType emotionType, User user) {
+        PostEmotion postEmotion = new PostEmotion();
+        postEmotion.post = post;
+        postEmotion.emotionType = emotionType;
+        postEmotion.user = user;
+        return postEmotion;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public EmotionType getEmotionType() {
+        return emotionType;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/java/com/dnd/webbb/global/common/entity/BaseCreatedEntity.java
+++ b/src/main/java/com/dnd/webbb/global/common/entity/BaseCreatedEntity.java
@@ -1,0 +1,21 @@
+package com.dnd.webbb.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseCreatedEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/dnd/webbb/monster/domain/HpActionType.java
+++ b/src/main/java/com/dnd/webbb/monster/domain/HpActionType.java
@@ -1,0 +1,7 @@
+package com.dnd.webbb.monster.domain;
+
+public enum HpActionType {
+    POST_LIKE,
+    COMMENT,
+    COMMENT_LIKE
+}

--- a/src/main/java/com/dnd/webbb/monster/domain/Monster.java
+++ b/src/main/java/com/dnd/webbb/monster/domain/Monster.java
@@ -1,0 +1,89 @@
+package com.dnd.webbb.monster.domain;
+
+import com.dnd.webbb.emotion.domain.EmotionType;
+import com.dnd.webbb.global.common.entity.BaseEntity;
+import com.dnd.webbb.post.domain.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+        name = "monster",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
+public class Monster extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private EmotionType emotionType;
+
+    @Column(nullable = false)
+    private int hp;
+
+    @Column(nullable = false)
+    private int maxHp;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private MonsterStatus status = MonsterStatus.ALIVE;
+
+    protected Monster() {}
+
+    public static Monster create(Post post, EmotionType emotionType, int maxHp) {
+        Monster monster = new Monster();
+        monster.post = post;
+        monster.emotionType = emotionType;
+        monster.maxHp = maxHp;
+        monster.hp = maxHp;
+        monster.status = MonsterStatus.ALIVE;
+        return monster;
+    }
+
+    public void decreaseHp(int delta) {
+        this.hp = Math.max(0, this.hp - delta);
+        if (this.hp == 0) {
+            this.status = MonsterStatus.DEAD;
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public EmotionType getEmotionType() {
+        return emotionType;
+    }
+
+    public int getHp() {
+        return hp;
+    }
+
+    public int getMaxHp() {
+        return maxHp;
+    }
+
+    public MonsterStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/dnd/webbb/monster/domain/MonsterHpLog.java
+++ b/src/main/java/com/dnd/webbb/monster/domain/MonsterHpLog.java
@@ -1,0 +1,114 @@
+package com.dnd.webbb.monster.domain;
+
+import com.dnd.webbb.comment.domain.Comment;
+import com.dnd.webbb.global.common.entity.BaseCreatedEntity;
+import com.dnd.webbb.post.domain.Post;
+import com.dnd.webbb.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "monster_hp_log")
+public class MonsterHpLog extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "monster_id", nullable = false)
+    private Monster monster;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private HpActionType actionType;
+
+    @Column(nullable = false)
+    private int hpDelta;
+
+    @Column(nullable = false)
+    private int beforeHp;
+
+    @Column(nullable = false)
+    private int afterHp;
+
+    protected MonsterHpLog() {}
+
+    public static MonsterHpLog create(
+            Monster monster,
+            User user,
+            Post post,
+            Comment comment,
+            HpActionType actionType,
+            int hpDelta,
+            int beforeHp,
+            int afterHp) {
+        MonsterHpLog log = new MonsterHpLog();
+        log.monster = monster;
+        log.user = user;
+        log.post = post;
+        log.comment = comment;
+        log.actionType = actionType;
+        log.hpDelta = hpDelta;
+        log.beforeHp = beforeHp;
+        log.afterHp = afterHp;
+        return log;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Monster getMonster() {
+        return monster;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public Comment getComment() {
+        return comment;
+    }
+
+    public HpActionType getActionType() {
+        return actionType;
+    }
+
+    public int getHpDelta() {
+        return hpDelta;
+    }
+
+    public int getBeforeHp() {
+        return beforeHp;
+    }
+
+    public int getAfterHp() {
+        return afterHp;
+    }
+}

--- a/src/main/java/com/dnd/webbb/monster/domain/MonsterStatus.java
+++ b/src/main/java/com/dnd/webbb/monster/domain/MonsterStatus.java
@@ -1,0 +1,6 @@
+package com.dnd.webbb.monster.domain;
+
+public enum MonsterStatus {
+    ALIVE,
+    DEAD
+}

--- a/src/main/java/com/dnd/webbb/post/domain/Post.java
+++ b/src/main/java/com/dnd/webbb/post/domain/Post.java
@@ -1,0 +1,120 @@
+package com.dnd.webbb.post.domain;
+
+import com.dnd.webbb.category.domain.BoardCategory;
+import com.dnd.webbb.global.common.entity.BaseEntity;
+import com.dnd.webbb.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "post")
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private BoardCategory category;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private int viewCount = 0;
+
+    @Column(nullable = false)
+    private int likeCount = 0;
+
+    @Column(nullable = false)
+    private int commentCount = 0;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    protected Post() {}
+
+    public static Post create(User user, BoardCategory category, String title, String content) {
+        Post post = new Post();
+        post.user = user;
+        post.category = category;
+        post.title = title;
+        post.content = content;
+        return post;
+    }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    public void incrementCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decrementCommentCount() {
+        if (this.commentCount > 0) {
+            this.commentCount--;
+        }
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public BoardCategory getCategory() {
+        return category;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public int getViewCount() {
+        return viewCount;
+    }
+
+    public int getLikeCount() {
+        return likeCount;
+    }
+
+    public int getCommentCount() {
+        return commentCount;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+}

--- a/src/main/java/com/dnd/webbb/post/domain/PostLike.java
+++ b/src/main/java/com/dnd/webbb/post/domain/PostLike.java
@@ -1,0 +1,53 @@
+package com.dnd.webbb.post.domain;
+
+import com.dnd.webbb.global.common.entity.BaseCreatedEntity;
+import com.dnd.webbb.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+        name = "post_like",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "user_id"}))
+public class PostLike extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    protected PostLike() {}
+
+    public static PostLike create(Post post, User user) {
+        PostLike postLike = new PostLike();
+        postLike.post = post;
+        postLike.user = user;
+        return postLike;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/java/com/dnd/webbb/report/domain/Report.java
+++ b/src/main/java/com/dnd/webbb/report/domain/Report.java
@@ -1,0 +1,111 @@
+package com.dnd.webbb.report.domain;
+
+import com.dnd.webbb.comment.domain.Comment;
+import com.dnd.webbb.global.common.entity.BaseCreatedEntity;
+import com.dnd.webbb.post.domain.Post;
+import com.dnd.webbb.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report")
+public class Report extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_user_id", nullable = false)
+    private User reporterUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private ReportType reportType;
+
+    @Column(nullable = false, length = 500)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private ReportStatus status = ReportStatus.PENDING;
+
+    private LocalDateTime processedAt;
+
+    protected Report() {}
+
+    public static Report createPostReport(User reporterUser, Post post, String reason) {
+        Report report = new Report();
+        report.reporterUser = reporterUser;
+        report.post = post;
+        report.reportType = ReportType.POST;
+        report.reason = reason;
+        return report;
+    }
+
+    public static Report createCommentReport(
+            User reporterUser, Post post, Comment comment, String reason) {
+        Report report = new Report();
+        report.reporterUser = reporterUser;
+        report.post = post;
+        report.comment = comment;
+        report.reportType = ReportType.COMMENT;
+        report.reason = reason;
+        return report;
+    }
+
+    public void process(ReportStatus status) {
+        this.status = status;
+        this.processedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getReporterUser() {
+        return reporterUser;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public Comment getComment() {
+        return comment;
+    }
+
+    public ReportType getReportType() {
+        return reportType;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public ReportStatus getStatus() {
+        return status;
+    }
+
+    public LocalDateTime getProcessedAt() {
+        return processedAt;
+    }
+}

--- a/src/main/java/com/dnd/webbb/report/domain/ReportStatus.java
+++ b/src/main/java/com/dnd/webbb/report/domain/ReportStatus.java
@@ -1,0 +1,7 @@
+package com.dnd.webbb.report.domain;
+
+public enum ReportStatus {
+    PENDING,
+    REVIEWED,
+    REJECTED
+}

--- a/src/main/java/com/dnd/webbb/report/domain/ReportType.java
+++ b/src/main/java/com/dnd/webbb/report/domain/ReportType.java
@@ -1,0 +1,6 @@
+package com.dnd.webbb.report.domain;
+
+public enum ReportType {
+    POST,
+    COMMENT
+}

--- a/src/main/java/com/dnd/webbb/user/application/UserService.java
+++ b/src/main/java/com/dnd/webbb/user/application/UserService.java
@@ -35,10 +35,10 @@ public class UserService {
         return UserResponse.from(userRepository.save(user));
     }
 
-    public UserResponse getUser(UUID id) {
+    public UserResponse getUser(UUID publicId) {
         User user =
                 userRepository
-                        .findByPublicIdAndDeletedAtIsNull(id)
+                        .findByPublicIdAndDeletedAtIsNull(publicId)
                         .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
         return UserResponse.from(user);
     }
@@ -50,20 +50,20 @@ public class UserService {
     }
 
     @Transactional
-    public UserResponse updateUser(UUID id, UserUpdateRequest request) {
+    public UserResponse updateUser(UUID publicId, UserUpdateRequest request) {
         User user =
                 userRepository
-                        .findByPublicIdAndDeletedAtIsNull(id)
+                        .findByPublicIdAndDeletedAtIsNull(publicId)
                         .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
-        user.update(request.nickname(), request.status());
+        user.update(request.nickname(), request.jobType(), request.careerLevel());
         return UserResponse.from(user);
     }
 
     @Transactional
-    public void withdrawUser(UUID id) {
+    public void withdrawUser(UUID publicId) {
         User user =
                 userRepository
-                        .findByPublicIdAndDeletedAtIsNull(id)
+                        .findByPublicIdAndDeletedAtIsNull(publicId)
                         .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
         user.withdraw();
     }

--- a/src/main/java/com/dnd/webbb/user/domain/OAuthProvider.java
+++ b/src/main/java/com/dnd/webbb/user/domain/OAuthProvider.java
@@ -1,0 +1,7 @@
+package com.dnd.webbb.user.domain;
+
+public enum OAuthProvider {
+    GOOGLE,
+    KAKAO,
+    NAVER
+}

--- a/src/main/java/com/dnd/webbb/user/domain/User.java
+++ b/src/main/java/com/dnd/webbb/user/domain/User.java
@@ -3,8 +3,6 @@ package com.dnd.webbb.user.domain;
 import com.dnd.webbb.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,15 +21,23 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true, updatable = false)
     private UUID publicId;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true, nullable = false, length = 100)
     private String email;
 
-    @Column(nullable = false)
+    @Column(length = 255)
+    private String passwordHash;
+
+    @Column(unique = true, nullable = false, length = 50)
     private String nickname;
 
-    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private String jobType;
+
+    @Column(length = 50)
+    private String careerLevel;
+
     @Column(nullable = false)
-    private UserStatus status;
+    private boolean isActive = true;
 
     private LocalDateTime deletedAt;
 
@@ -42,21 +48,24 @@ public class User extends BaseEntity {
         user.publicId = UUID.randomUUID();
         user.email = email;
         user.nickname = nickname;
-        user.status = UserStatus.ACTIVE;
+        user.isActive = true;
         return user;
     }
 
-    public void update(String nickname, UserStatus status) {
+    public void update(String nickname, String jobType, String careerLevel) {
         if (nickname != null) {
             this.nickname = nickname;
         }
-        if (status != null) {
-            this.status = status;
+        if (jobType != null) {
+            this.jobType = jobType;
+        }
+        if (careerLevel != null) {
+            this.careerLevel = careerLevel;
         }
     }
 
     public void withdraw() {
-        this.status = UserStatus.INACTIVE;
+        this.isActive = false;
         this.deletedAt = LocalDateTime.now();
     }
 
@@ -72,12 +81,24 @@ public class User extends BaseEntity {
         return email;
     }
 
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
     public String getNickname() {
         return nickname;
     }
 
-    public UserStatus getStatus() {
-        return status;
+    public String getJobType() {
+        return jobType;
+    }
+
+    public String getCareerLevel() {
+        return careerLevel;
+    }
+
+    public boolean isActive() {
+        return isActive;
     }
 
     public LocalDateTime getDeletedAt() {

--- a/src/main/java/com/dnd/webbb/user/domain/UserOauth.java
+++ b/src/main/java/com/dnd/webbb/user/domain/UserOauth.java
@@ -1,0 +1,63 @@
+package com.dnd.webbb.user.domain;
+
+import com.dnd.webbb.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+        name = "user_oauth",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_user_id"}))
+public class UserOauth extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OAuthProvider provider;
+
+    @Column(name = "provider_user_id", nullable = false, length = 100)
+    private String providerUserId;
+
+    protected UserOauth() {}
+
+    public static UserOauth create(User user, OAuthProvider provider, String providerUserId) {
+        UserOauth oauth = new UserOauth();
+        oauth.user = user;
+        oauth.provider = provider;
+        oauth.providerUserId = providerUserId;
+        return oauth;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public OAuthProvider getProvider() {
+        return provider;
+    }
+
+    public String getProviderUserId() {
+        return providerUserId;
+    }
+}

--- a/src/main/java/com/dnd/webbb/user/domain/UserRepository.java
+++ b/src/main/java/com/dnd/webbb/user/domain/UserRepository.java
@@ -6,8 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByIdAndDeletedAtIsNull(Long id);
-
     Optional<User> findByPublicIdAndDeletedAtIsNull(UUID publicId);
 
     boolean existsByEmailAndDeletedAtIsNull(String email);

--- a/src/main/java/com/dnd/webbb/user/domain/UserStatus.java
+++ b/src/main/java/com/dnd/webbb/user/domain/UserStatus.java
@@ -1,6 +1,0 @@
-package com.dnd.webbb.user.domain;
-
-public enum UserStatus {
-    ACTIVE,
-    INACTIVE
-}

--- a/src/main/java/com/dnd/webbb/user/interfaces/UserController.java
+++ b/src/main/java/com/dnd/webbb/user/interfaces/UserController.java
@@ -58,13 +58,15 @@ public class UserController {
                           "success": true,
                           "message": "회원이 생성되었습니다.",
                           "data": {
-                            "id": "01939b10-7b0f-7c8f-9a2b-111111111111",
+                            "id": 1,
                             "email": "test@test.com",
                             "nickname": "ogu",
-                            "status": "ACTIVE",
-                            "createdAt": "2026-04-09T12:00:00"
+                            "jobType": null,
+                            "careerLevel": null,
+                            "isActive": true,
+                            "createdAt": "2026-05-03T12:00:00"
                           },
-                          "timestamp": "2026-04-09T12:00:00"
+                          "timestamp": "2026-05-03T12:00:00"
                         }
                         """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -81,9 +83,9 @@ public class UserController {
                           "message": "유효하지 않은 요청입니다.",
                           "errors": [
                             { "field": "email", "reason": "이메일 형식이 올바르지 않습니다." },
-                            { "field": "nickname", "reason": "닉네임은 10자 이하여야 합니다." }
+                            { "field": "nickname", "reason": "닉네임은 50자 이하여야 합니다." }
                           ],
-                          "timestamp": "2026-04-09T12:00:00"
+                          "timestamp": "2026-05-03T12:00:00"
                         }
                         """)))
     })
@@ -109,13 +111,15 @@ public class UserController {
                           "success": true,
                           "message": "요청이 성공했습니다.",
                           "data": {
-                            "id": "01939b10-7b0f-7c8f-9a2b-111111111111",
+                            "id": 1,
                             "email": "test@test.com",
                             "nickname": "ogu",
-                            "status": "ACTIVE",
-                            "createdAt": "2026-04-09T12:00:00"
+                            "jobType": "BACKEND",
+                            "careerLevel": "3년차",
+                            "isActive": true,
+                            "createdAt": "2026-05-03T12:00:00"
                           },
-                          "timestamp": "2026-04-09T12:00:00"
+                          "timestamp": "2026-05-03T12:00:00"
                         }
                         """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -130,7 +134,7 @@ public class UserController {
                         {
                           "success": false,
                           "message": "존재하지 않는 회원입니다.",
-                          "timestamp": "2026-04-09T12:00:00"
+                          "timestamp": "2026-05-03T12:00:00"
                         }
                         """)))
     })
@@ -155,12 +159,12 @@ public class UserController {
                           "message": "요청이 성공했습니다.",
                           "data": {
                             "users": [
-                              { "id": "01939b10-7b0f-7c8f-9a2b-222222222222", "email": "b@test.com", "nickname": "bbb", "status": "ACTIVE", "createdAt": "2026-04-09T11:00:00" },
-                              { "id": "01939b10-7b0f-7c8f-9a2b-111111111111", "email": "a@test.com", "nickname": "aaa", "status": "ACTIVE", "createdAt": "2026-04-09T10:00:00" }
+                              { "id": 2, "email": "b@test.com", "nickname": "bbb", "jobType": null, "careerLevel": null, "isActive": true, "createdAt": "2026-05-03T11:00:00" },
+                              { "id": 1, "email": "a@test.com", "nickname": "aaa", "jobType": null, "careerLevel": null, "isActive": true, "createdAt": "2026-05-03T10:00:00" }
                             ],
-                            "nextCursor": 19
+                            "nextCursor": 1
                           },
-                          "timestamp": "2026-04-09T12:00:00"
+                          "timestamp": "2026-05-03T12:00:00"
                         }
                         """)))
     })
@@ -191,31 +195,15 @@ public class UserController {
                           "success": true,
                           "message": "요청이 성공했습니다.",
                           "data": {
-                            "id": "01939b10-7b0f-7c8f-9a2b-111111111111",
+                            "id": 1,
                             "email": "test@test.com",
                             "nickname": "newname",
-                            "status": "ACTIVE",
-                            "createdAt": "2026-04-09T12:00:00"
+                            "jobType": "BACKEND",
+                            "careerLevel": "3년차",
+                            "isActive": true,
+                            "createdAt": "2026-05-03T12:00:00"
                           },
-                          "timestamp": "2026-04-09T12:00:00"
-                        }
-                        """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "유효성 검증 실패",
-                content =
-                        @Content(
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                        {
-                          "success": false,
-                          "message": "유효하지 않은 요청입니다.",
-                          "errors": [
-                            { "field": "nickname", "reason": "닉네임은 10자 이하여야 합니다." }
-                          ],
-                          "timestamp": "2026-04-09T12:00:00"
+                          "timestamp": "2026-05-03T12:00:00"
                         }
                         """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -230,7 +218,7 @@ public class UserController {
                         {
                           "success": false,
                           "message": "존재하지 않는 회원입니다.",
-                          "timestamp": "2026-04-09T12:00:00"
+                          "timestamp": "2026-05-03T12:00:00"
                         }
                         """)))
     })
@@ -257,7 +245,7 @@ public class UserController {
                         {
                           "success": false,
                           "message": "존재하지 않는 회원입니다.",
-                          "timestamp": "2026-04-09T12:00:00"
+                          "timestamp": "2026-05-03T12:00:00"
                         }
                         """)))
     })

--- a/src/main/java/com/dnd/webbb/user/interfaces/dto/UserCreateRequest.java
+++ b/src/main/java/com/dnd/webbb/user/interfaces/dto/UserCreateRequest.java
@@ -12,5 +12,5 @@ public record UserCreateRequest(
                 String email,
         @Schema(example = "ogu")
                 @NotBlank(message = "닉네임은 필수입니다.")
-                @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
+                @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
                 String nickname) {}

--- a/src/main/java/com/dnd/webbb/user/interfaces/dto/UserResponse.java
+++ b/src/main/java/com/dnd/webbb/user/interfaces/dto/UserResponse.java
@@ -5,14 +5,22 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record UserResponse(
-        UUID id, String email, String nickname, String status, LocalDateTime createdAt) {
+        UUID id,
+        String email,
+        String nickname,
+        String jobType,
+        String careerLevel,
+        boolean isActive,
+        LocalDateTime createdAt) {
 
     public static UserResponse from(User user) {
         return new UserResponse(
                 user.getPublicId(),
                 user.getEmail(),
                 user.getNickname(),
-                user.getStatus().name(),
+                user.getJobType(),
+                user.getCareerLevel(),
+                user.isActive(),
                 user.getCreatedAt());
     }
 }

--- a/src/main/java/com/dnd/webbb/user/interfaces/dto/UserUpdateRequest.java
+++ b/src/main/java/com/dnd/webbb/user/interfaces/dto/UserUpdateRequest.java
@@ -1,10 +1,10 @@
 package com.dnd.webbb.user.interfaces.dto;
 
-import com.dnd.webbb.user.domain.UserStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
 public record UserUpdateRequest(
-        @Schema(example = "newname") @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
+        @Schema(example = "newname") @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
                 String nickname,
-        @Schema(example = "INACTIVE") UserStatus status) {}
+        @Schema(example = "BACKEND") String jobType,
+        @Schema(example = "3년차") String careerLevel) {}


### PR DESCRIPTION
## PR 제목(내용 요약)
[BE] feat: ERD 기반 JPA 엔티티 전체 구성

## 📌 변경 내용 & 이유

### 신규 추가
- `BaseCreatedEntity` — `createdAt`만 포함하는 불변 로그 엔티티 기반 클래스 추가
- `UserOauth` — OAuth 제공자별 소셜 로그인 정보 분리 (GOOGLE / KAKAO / NAVER)
- `BoardCategory` — 게시글 카테고리 마스터
- `Post` / `PostLike` — 게시글 및 좋아요 이력 (likeCount / commentCount 역정규화 캐시)
- `Comment` / `CommentLike` — 댓글 / 대댓글 (자기참조), 댓글 좋아요 이력
- `EmotionType` enum / `PostEmotion` — 감정 종류 및 게시글 감정 선택 (게시글당 1개 UNIQUE)
- `Monster` / `MonsterHpLog` — 감정 기반 몬스터 및 HP 변경 이력
- `Report` — 게시글 / 댓글 신고

### User 도메인 재설계
- `publicId` (UUID) 추가 — API 경로에 순번 ID 대신 UUID 노출
- `isActive` (boolean), `passwordHash`, `jobType`, `careerLevel` 추가
- `UserStatus` enum 제거
- CRUD API 경로 파라미터 UUID 기반으로 변경

### 설계 원칙
- 도메인 간 참조: `@ManyToOne(fetch = LAZY)`
- 소프트 삭제: User → `isActive + deletedAt` / Post·Comment → `isDeleted`
- 불변 엔티티(PostLike, CommentLike, PostEmotion, MonsterHpLog): `BaseCreatedEntity` 상속

## 📸 스크린샷 (선택)
> UI 변경 없음

## 🧪 테스트 방법 (선택)
1. `./gradlew bootRun` 실행 후 Hibernate DDL 로그에서 테이블 생성 확인
2. Swagger UI(`/swagger-ui.html`) → User CRUD API UUID 기반 동작 확인
3. `POST /api/users` → 생성된 회원의 `id` 필드가 UUID 형태인지 확인
4. `DELETE /api/users/{uuid}` → 정상 탈퇴 처리 확인

## 📢 논의하고 싶은 내용
- `EmotionType`을 DB 테이블 대신 Java enum으로 처리했습니다. 향후 관리자가 감정 종류를 동적으로 추가해야 하는 요구사항이 생기면 JPA 엔티티로 전환이 필요합니다.
- `Post.likeCount` / `commentCount` 역정규화 캐시를 Service 레이어에서 직접 +1/-1 관리합니다. 동시성 이슈가 우려되면 추후 Redis 캐시나 낙관적 락 도입을 검토할 수 있습니다.

## 🧩 관련 이슈
Close #13