### PR TITLE
API 명세 기반 스텁 컨트롤러 구현

### DIFF
--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/application/RetrospectiveService.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/application/RetrospectiveService.java
@@ -26,7 +26,8 @@ public class RetrospectiveService {
         try {
             KptAnalysis analysis = analyzer.analyze(context);
             if (analysis.isEmpty()) {
-                return new RetrospectiveResult.Failure(ErrorCode.EMPTY_RESPONSE, "AI returned empty analysis");
+                return new RetrospectiveResult.Failure(
+                        ErrorCode.EMPTY_RESPONSE, "AI returned empty analysis");
             }
             return new RetrospectiveResult.Success(analysis);
         } catch (RetrospectiveGenerationException e) {

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiConfig.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiConfig.java
@@ -1,5 +1,9 @@
 package com.dnd.poc.retrospective.config;
 
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,11 +13,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
-
-import java.io.IOException;
-import java.net.http.HttpClient;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 
 @Configuration
 @EnableConfigurationProperties(AiProperties.class)
@@ -45,7 +44,8 @@ public class AiConfig {
 
     @Bean
     @ConditionalOnExpression(LIVE_KEY_CONDITION)
-    public KptSystemPrompt kptSystemPrompt(AiProperties props, ResourceLoader loader) throws IOException {
+    public KptSystemPrompt kptSystemPrompt(AiProperties props, ResourceLoader loader)
+            throws IOException {
         Resource resource = loader.getResource(props.promptLocation());
         try (var in = resource.getInputStream()) {
             return new KptSystemPrompt(new String(in.readAllBytes(), StandardCharsets.UTF_8));

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiProperties.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiProperties.java
@@ -3,15 +3,10 @@ package com.dnd.poc.retrospective.config;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import java.time.Duration;
-
 @Validated
 @ConfigurationProperties(prefix = "retrospective.ai")
-public record AiProperties(
-        @NotBlank String promptLocation,
-        @NotNull @Positive Duration timeout
-) {
-}
+public record AiProperties(@NotBlank String promptLocation, @NotNull @Positive Duration timeout) {}

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/OpenApiConfig.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/OpenApiConfig.java
@@ -12,11 +12,18 @@ class OpenApiConfig {
 
     @Bean
     OpenAPI retrospectiveOpenApi() {
-        return new OpenAPI().info(new Info()
-                .title("Retrospective AI API")
-                .version("0.0.1")
-                .description("취준생의 감정 텍스트를 KPT(Keep/Problem/Try) + 응원 메시지로 구조화하는 AI 회고 도우미.")
-                .contact(new Contact().name("DDD-13 WEBBB").url("https://github.com/DDD-Community/DDD-13-WEBBB_BE"))
-                .license(new License().name("Internal PoC")));
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("Retrospective AI API")
+                                .version("0.0.1")
+                                .description(
+                                        "취준생의 감정 텍스트를 KPT(Keep/Problem/Try) + 응원 메시지로 구조화하는 AI 회고 도우미.")
+                                .contact(
+                                        new Contact()
+                                                .name("DDD-13 WEBBB")
+                                                .url(
+                                                        "https://github.com/DDD-Community/DDD-13-WEBBB_BE"))
+                                .license(new License().name("Internal PoC")));
     }
 }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/domain/KptAnalysis.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/domain/KptAnalysis.java
@@ -4,11 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 public record KptAnalysis(
-        List<String> keep,
-        List<String> problem,
-        List<String> tries,
-        String cheerMessage
-) {
+        List<String> keep, List<String> problem, List<String> tries, String cheerMessage) {
     public KptAnalysis {
         Objects.requireNonNull(keep, "keep must not be null");
         Objects.requireNonNull(problem, "problem must not be null");

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/FallbackKptAnalyzer.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/FallbackKptAnalyzer.java
@@ -4,30 +4,26 @@ import com.dnd.poc.retrospective.application.port.KptAnalyzer;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.dnd.poc.retrospective.domain.RetrospectiveContext;
 import com.dnd.poc.retrospective.domain.exception.RetryableUpstreamException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 /**
- * 다중 모델 안정성을 위한 Fallback 어댑터입니다.
- * 실서비스 시나리오에서 주 모델(OpenAI) 장애 시 보조 모델이나 Mock으로 전환하여 서비스 가용성을 보장합니다.
+ * 다중 모델 안정성을 위한 Fallback 어댑터입니다. 실서비스 시나리오에서 주 모델(OpenAI) 장애 시 보조 모델이나 Mock으로 전환하여 서비스 가용성을 보장합니다.
  */
 @Primary
 @Component
 class FallbackKptAnalyzer implements KptAnalyzer {
 
     private static final Logger log = LoggerFactory.getLogger(FallbackKptAnalyzer.class);
-    
+
     private final List<KptAnalyzer> analyzers;
 
     FallbackKptAnalyzer(List<KptAnalyzer> analyzers) {
         // FallbackKptAnalyzer 자체를 제외한 나머지 분석기들을 수집
-        this.analyzers = analyzers.stream()
-                .filter(a -> a != this)
-                .toList();
+        this.analyzers = analyzers.stream().filter(a -> a != this).toList();
     }
 
     @Override
@@ -39,8 +35,10 @@ class FallbackKptAnalyzer implements KptAnalyzer {
                 log.info("Attempting analysis with: {}", analyzer.getClass().getSimpleName());
                 return analyzer.analyze(context);
             } catch (RetryableUpstreamException e) {
-                log.warn("Analyzer {} failed, trying next. error={}", 
-                        analyzer.getClass().getSimpleName(), e.getMessage());
+                log.warn(
+                        "Analyzer {} failed, trying next. error={}",
+                        analyzer.getClass().getSimpleName(),
+                        e.getMessage());
                 lastException = e;
             }
         }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/KptResponse.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/KptResponse.java
@@ -1,13 +1,10 @@
 package com.dnd.poc.retrospective.infrastructure.ai;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 record KptResponse(
         List<String> keep,
         List<String> problem,
         @JsonProperty("try") List<String> tries,
-        @JsonProperty("cheer_message") String cheerMessage
-) {
-}
+        @JsonProperty("cheer_message") String cheerMessage) {}

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/MockKptAnalyzer.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/MockKptAnalyzer.java
@@ -5,12 +5,11 @@ import com.dnd.poc.retrospective.config.AiConfig;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.dnd.poc.retrospective.domain.RetrospectiveContext;
 import jakarta.annotation.PostConstruct;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @ConditionalOnExpression(AiConfig.MOCK_KEY_CONDITION)
@@ -30,20 +29,10 @@ class MockKptAnalyzer implements KptAnalyzer {
     public KptAnalysis analyze(RetrospectiveContext context) {
         log.debug("Mock analyze invoked. length={}", context.length());
         return new KptAnalysis(
-                List.of(
-                        "끝까지 자리에 앉아 시도를 멈추지 않은 점",
-                        "본인 부족한 부분을 솔직히 인지하고 표현한 점"
-                ),
-                List.of(
-                        "시간 분배 전략이 정해져 있지 않음",
-                        "어려운 문제에서 손을 떼는 시점을 정해두지 않음"
-                ),
-                List.of(
-                        "내일 30분 동안 약점 영역 1챕터 복습하기",
-                        "타이머 두고 1문제 25분 룰 적용해보기"
-                ),
-                "오늘도 시도한 것만으로 충분히 잘하고 계세요. 한 걸음씩 가요."
-        );
+                List.of("끝까지 자리에 앉아 시도를 멈추지 않은 점", "본인 부족한 부분을 솔직히 인지하고 표현한 점"),
+                List.of("시간 분배 전략이 정해져 있지 않음", "어려운 문제에서 손을 떼는 시점을 정해두지 않음"),
+                List.of("내일 30분 동안 약점 영역 1챕터 복습하기", "타이머 두고 1문제 25분 룰 적용해보기"),
+                "오늘도 시도한 것만으로 충분히 잘하고 계세요. 한 걸음씩 가요.");
     }
 
     @Override

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/SpringAiKptAnalyzer.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/SpringAiKptAnalyzer.java
@@ -1,6 +1,7 @@
 package com.dnd.poc.retrospective.infrastructure.ai;
 
 import com.dnd.poc.retrospective.application.port.KptAnalyzer;
+import com.dnd.poc.retrospective.config.AiConfig;
 import com.dnd.poc.retrospective.config.AiConfig.KptSystemPrompt;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.dnd.poc.retrospective.domain.RetrospectiveContext;
@@ -11,18 +12,16 @@ import com.dnd.poc.retrospective.domain.exception.RetryableUpstreamException;
 import com.fasterxml.jackson.core.JacksonException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.dnd.poc.retrospective.config.AiConfig;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClientException;
-
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.net.http.HttpTimeoutException;
 import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 
 @Component
 @ConditionalOnExpression(AiConfig.LIVE_KEY_CONDITION)
@@ -95,11 +94,7 @@ class SpringAiKptAnalyzer implements KptAnalyzer {
         }
         try {
             return new KptAnalysis(
-                    response.keep(),
-                    response.problem(),
-                    response.tries(),
-                    response.cheerMessage()
-            );
+                    response.keep(), response.problem(), response.tries(), response.cheerMessage());
         } catch (NullPointerException | IllegalArgumentException e) {
             throw new PermanentResponseException(
                     ErrorCode.INVALID_RESPONSE, "AI response invalid: " + e.getMessage(), e);

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/CorrelationIdFilter.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/CorrelationIdFilter.java
@@ -4,14 +4,13 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.UUID;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -21,9 +20,9 @@ class CorrelationIdFilter extends OncePerRequestFilter {
     private static final String MDC_KEY = "correlationId";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain chain) throws ServletException, IOException {
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
         String id = request.getHeader(HEADER);
         if (id == null || id.isBlank()) {
             id = UUID.randomUUID().toString();

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/RetrospectiveController.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/RetrospectiveController.java
@@ -5,7 +5,6 @@ import com.dnd.poc.retrospective.domain.RetrospectiveContext;
 import com.dnd.poc.retrospective.domain.RetrospectiveResult;
 import com.dnd.poc.retrospective.domain.RetrospectiveResult.Failure;
 import com.dnd.poc.retrospective.domain.RetrospectiveResult.Success;
-import com.dnd.poc.retrospective.domain.exception.RetrospectiveGenerationException;
 import com.dnd.poc.retrospective.interfaces.dto.RetrospectiveRequest;
 import com.dnd.poc.retrospective.interfaces.dto.RetrospectiveResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,24 +35,43 @@ public class RetrospectiveController {
 
     @Operation(
             summary = "KPT 회고 분석",
-            description = "취준생의 텍스트를 KPT(Keep/Problem/Try) 프레임워크와 응원 메시지로 구조화해 반환합니다."
-    )
+            description = "취준생의 텍스트를 KPT(Keep/Problem/Try) 프레임워크와 응원 메시지로 구조화해 반환합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "분석 성공",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = RetrospectiveResponse.class))),
-            @ApiResponse(responseCode = "400", description = "입력 검증 실패 (빈 값 / 2000자 초과)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class))),
-            @ApiResponse(responseCode = "422", description = "AI 응답이 빈/잘못된 형식 (EMPTY_RESPONSE, INVALID_RESPONSE)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class))),
-            @ApiResponse(responseCode = "502", description = "업스트림 LLM 호출 실패 (UPSTREAM_UNAVAILABLE)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class))),
-            @ApiResponse(responseCode = "504", description = "업스트림 LLM 타임아웃 (UPSTREAM_TIMEOUT)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class)))
+        @ApiResponse(
+                responseCode = "200",
+                description = "분석 성공",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                schema = @Schema(implementation = RetrospectiveResponse.class))),
+        @ApiResponse(
+                responseCode = "400",
+                description = "입력 검증 실패 (빈 값 / 2000자 초과)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "AI 응답이 빈/잘못된 형식 (EMPTY_RESPONSE, INVALID_RESPONSE)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class))),
+        @ApiResponse(
+                responseCode = "502",
+                description = "업스트림 LLM 호출 실패 (UPSTREAM_UNAVAILABLE)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class))),
+        @ApiResponse(
+                responseCode = "504",
+                description = "업스트림 LLM 타임아웃 (UPSTREAM_TIMEOUT)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class)))
     })
     @PostMapping(value = "/analyze", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> analyze(@Valid @RequestBody RetrospectiveRequest request) {
@@ -62,9 +80,11 @@ public class RetrospectiveController {
         return switch (result) {
             case Success s -> ResponseEntity.ok(RetrospectiveResponse.from(s.analysis()));
             case Failure f -> {
-                ProblemDetail pd = ProblemDetail.forStatusAndDetail(
-                        org.springframework.http.HttpStatusCode.valueOf(f.code().getHttpStatus()),
-                        "AI 회고 생성에 실패했습니다.");
+                ProblemDetail pd =
+                        ProblemDetail.forStatusAndDetail(
+                                org.springframework.http.HttpStatusCode.valueOf(
+                                        f.code().getHttpStatus()),
+                                "AI 회고 생성에 실패했습니다.");
                 pd.setProperty("errorCode", f.code().name());
                 yield ResponseEntity.status(f.code().getHttpStatus()).body(pd);
             }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveRequest.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveRequest.java
@@ -8,14 +8,11 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "회고 분석 요청")
 public record RetrospectiveRequest(
         @Schema(
-                description = "사용자가 작성한 회고 원문 (1~2000자)",
-                example = "오늘 코테에서 시간이 부족해서 마지막 문제를 못 풀었어요. 자료구조 공부가 부족했던 것 같아요.",
-                minLength = 1,
-                maxLength = RetrospectiveContext.MAX_LENGTH,
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        @NotBlank(message = "context must not be blank")
-        @Size(max = RetrospectiveContext.MAX_LENGTH, message = "context too long")
-        String context
-) {
-}
+                        description = "사용자가 작성한 회고 원문 (1~2000자)",
+                        example = "오늘 코테에서 시간이 부족해서 마지막 문제를 못 풀었어요. 자료구조 공부가 부족했던 것 같아요.",
+                        minLength = 1,
+                        maxLength = RetrospectiveContext.MAX_LENGTH,
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                @NotBlank(message = "context must not be blank")
+                @Size(max = RetrospectiveContext.MAX_LENGTH, message = "context too long")
+                String context) {}

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveResponse.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveResponse.java
@@ -3,29 +3,21 @@ package com.dnd.poc.retrospective.interfaces.dto;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 @Schema(description = "KPT 분석 결과")
 public record RetrospectiveResponse(
         @Schema(description = "잘하고 있는 점", example = "[\"끝까지 시도한 점\",\"본인 약점을 객관화한 점\"]")
-        List<String> keep,
-
-        @Schema(description = "객관적·개선 가능한 사실", example = "[\"시간 분배 전략 부재\"]")
-        List<String> problem,
-
+                List<String> keep,
+        @Schema(description = "객관적·개선 가능한 사실", example = "[\"시간 분배 전략 부재\"]") List<String> problem,
         @Schema(description = "내일 실행할 수 있는 작은 액션", example = "[\"자료구조 30분 복습\"]")
-        @JsonProperty("try") List<String> tries,
-
+                @JsonProperty("try")
+                List<String> tries,
         @Schema(description = "따뜻한 위로·응원 한마디", example = "오늘도 시도한 것만으로 충분해요.")
-        @JsonProperty("cheer_message") String cheerMessage
-) {
+                @JsonProperty("cheer_message")
+                String cheerMessage) {
     public static RetrospectiveResponse from(KptAnalysis analysis) {
         return new RetrospectiveResponse(
-                analysis.keep(),
-                analysis.problem(),
-                analysis.tries(),
-                analysis.cheerMessage()
-        );
+                analysis.keep(), analysis.problem(), analysis.tries(), analysis.cheerMessage());
     }
 }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/exception/GlobalExceptionHandler.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.dnd.poc.retrospective.interfaces.exception;
 
 import com.dnd.poc.retrospective.domain.RetrospectiveResult.ErrorCode;
 import com.dnd.poc.retrospective.domain.exception.RetrospectiveGenerationException;
+import java.net.URI;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -9,9 +11,6 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.net.URI;
-import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -33,9 +32,10 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ProblemDetail handleValidation(MethodArgumentNotValidException e) {
-        String detail = e.getBindingResult().getFieldErrors().stream()
-                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
-                .collect(Collectors.joining(", "));
+        String detail =
+                e.getBindingResult().getFieldErrors().stream()
+                        .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                        .collect(Collectors.joining(", "));
         ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail);
         pd.setTitle("Validation failed");
         pd.setType(TYPE_VALIDATION);

--- a/src/main/java/com/ddd/webbb/auth/interfaces/AuthController.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/AuthController.java
@@ -1,0 +1,194 @@
+package com.ddd.webbb.auth.interfaces;
+
+import com.ddd.webbb.auth.interfaces.dto.AuthResponse;
+import com.ddd.webbb.auth.interfaces.dto.AuthResponse.TokenInfo;
+import com.ddd.webbb.auth.interfaces.dto.AuthResponse.UserInfo;
+import com.ddd.webbb.auth.interfaces.dto.EmailLoginRequest;
+import com.ddd.webbb.auth.interfaces.dto.EmailSignupRequest;
+import com.ddd.webbb.auth.interfaces.dto.OAuthLoginRequest;
+import com.ddd.webbb.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 API")
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private static final UserInfo STUB_USER =
+            new UserInfo(
+                    "01939b10-7b0f-7c8f-9a2b-111111111111",
+                    "ogu@test.com",
+                    "ogu",
+                    "DEVELOPMENT",
+                    "YEAR_3",
+                    "ACTIVE");
+
+    private static final TokenInfo STUB_TOKENS =
+            new TokenInfo("stub-access-token", "stub-refresh-token");
+
+    @Operation(summary = "SNS 로그인/회원가입")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "로그인 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "로그인에 성공했습니다.",
+                          "data": {
+                            "user": {
+                              "id": "01939b10-7b0f-7c8f-9a2b-111111111111",
+                              "email": "ogu@test.com",
+                              "nickname": "ogu",
+                              "jobRole": "DEVELOPMENT",
+                              "careerYear": "YEAR_3",
+                              "status": "ACTIVE"
+                            },
+                            "tokens": {
+                              "accessToken": "stub-access-token",
+                              "refreshToken": "stub-refresh-token"
+                            },
+                            "isNewUser": true
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @PostMapping("/oauth/{provider}")
+    public ApiResponse<AuthResponse> oauthLogin(
+            @Parameter(description = "GOOGLE | KAKAO | NAVER") @PathVariable String provider,
+            @RequestBody @Valid OAuthLoginRequest request) {
+        // TODO: 실제 서비스 연동
+        return ApiResponse.ok("로그인에 성공했습니다.", new AuthResponse(STUB_USER, STUB_TOKENS, true));
+    }
+
+    @Operation(summary = "이메일 회원가입")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "201",
+                description = "회원가입 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "회원가입에 성공했습니다.",
+                          "data": {
+                            "user": { "id": "01939b10-7b0f-7c8f-9a2b-111111111111", "email": "test@test.com", "nickname": "ogu", "jobRole": "DEVELOPMENT", "careerYear": "NEWCOMER", "status": "ACTIVE" },
+                            "tokens": { "accessToken": "stub-access-token", "refreshToken": "stub-refresh-token" },
+                            "isNewUser": true
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @PostMapping("/signup/email")
+    public ResponseEntity<ApiResponse<AuthResponse>> signupEmail(
+            @RequestBody @Valid EmailSignupRequest request) {
+        // TODO: 실제 서비스 연동
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(
+                        ApiResponse.ok(
+                                "회원가입에 성공했습니다.", new AuthResponse(STUB_USER, STUB_TOKENS, true)));
+    }
+
+    @Operation(summary = "이메일 로그인")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "로그인 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "로그인에 성공했습니다.",
+                          "data": {
+                            "user": { "id": "01939b10-7b0f-7c8f-9a2b-111111111111", "email": "test@test.com", "nickname": "ogu", "jobRole": "DEVELOPMENT", "careerYear": "YEAR_3", "status": "ACTIVE" },
+                            "tokens": { "accessToken": "stub-access-token", "refreshToken": "stub-refresh-token" },
+                            "isNewUser": false
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @PostMapping("/login/email")
+    public ApiResponse<AuthResponse> loginEmail(@RequestBody @Valid EmailLoginRequest request) {
+        // TODO: 실제 서비스 연동
+        return ApiResponse.ok("로그인에 성공했습니다.", new AuthResponse(STUB_USER, STUB_TOKENS, false));
+    }
+
+    @Operation(summary = "로그아웃")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "로그아웃 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "로그아웃에 성공했습니다.",
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout() {
+        // TODO: 실제 서비스 연동
+        return ApiResponse.ok("로그아웃에 성공했습니다.", null);
+    }
+
+    @Operation(summary = "Access Token 재발급")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "토큰 재발급 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "토큰이 재발급되었습니다.",
+                          "data": { "accessToken": "new-stub-access-token", "refreshToken": "new-stub-refresh-token" },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @PostMapping("/refresh")
+    public ApiResponse<TokenInfo> refresh() {
+        // TODO: 실제 서비스 연동
+        return ApiResponse.ok(
+                "토큰이 재발급되었습니다.", new TokenInfo("new-stub-access-token", "new-stub-refresh-token"));
+    }
+}

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/AuthResponse.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/AuthResponse.java
@@ -1,0 +1,14 @@
+package com.ddd.webbb.auth.interfaces.dto;
+
+public record AuthResponse(UserInfo user, TokenInfo tokens, boolean isNewUser) {
+
+    public record UserInfo(
+            String id,
+            String email,
+            String nickname,
+            String jobRole,
+            String careerYear,
+            String status) {}
+
+    public record TokenInfo(String accessToken, String refreshToken) {}
+}

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailLoginRequest.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailLoginRequest.java
@@ -1,0 +1,12 @@
+package com.ddd.webbb.auth.interfaces.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailLoginRequest(
+        @Schema(example = "test@test.com")
+                @NotBlank(message = "이메일은 필수입니다.")
+                @Email(message = "이메일 형식이 올바르지 않습니다.")
+                String email,
+        @Schema(example = "password123!") @NotBlank(message = "비밀번호는 필수입니다.") String password) {}

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailSignupRequest.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailSignupRequest.java
@@ -1,0 +1,22 @@
+package com.ddd.webbb.auth.interfaces.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record EmailSignupRequest(
+        @Schema(example = "test@test.com")
+                @NotBlank(message = "이메일은 필수입니다.")
+                @Email(message = "이메일 형식이 올바르지 않습니다.")
+                String email,
+        @Schema(example = "password123!")
+                @NotBlank(message = "비밀번호는 필수입니다.")
+                @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+                String password,
+        @Schema(example = "ogu")
+                @NotBlank(message = "닉네임은 필수입니다.")
+                @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
+                String nickname,
+        @Schema(example = "DEVELOPMENT") String jobRole,
+        @Schema(example = "NEWCOMER") String careerYear) {}

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/OAuthLoginRequest.java
@@ -1,0 +1,11 @@
+package com.ddd.webbb.auth.interfaces.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record OAuthLoginRequest(
+        @Schema(example = "provider-access-token") @NotBlank(message = "OAuth 액세스 토큰은 필수입니다.")
+                String oauthAccessToken,
+        @Schema(example = "ogu") String nickname,
+        @Schema(example = "DEVELOPMENT") String jobRole,
+        @Schema(example = "YEAR_3") String careerYear) {}

--- a/src/main/java/com/ddd/webbb/comment/interfaces/CommentController.java
+++ b/src/main/java/com/ddd/webbb/comment/interfaces/CommentController.java
@@ -1,0 +1,136 @@
+package com.ddd.webbb.comment.interfaces;
+
+import com.ddd.webbb.comment.interfaces.dto.CommentCreateRequest;
+import com.ddd.webbb.comment.interfaces.dto.CommentListResponse;
+import com.ddd.webbb.comment.interfaces.dto.CommentResponse;
+import com.ddd.webbb.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Comment", description = "댓글 API")
+@RestController
+@RequestMapping("/api")
+public class CommentController {
+
+    @Operation(summary = "댓글 작성")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "201",
+                description = "댓글 작성 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "댓글이 작성되었습니다.",
+                          "data": {
+                            "commentId": 1,
+                            "postId": 1,
+                            "content": "지금 많이 힘들겠지만, 여기까지 온 것만으로도 충분히 잘하고 있어요.",
+                            "monster": { "hp": 70, "maxHp": 100, "status": "ALIVE" },
+                            "createdAt": "2026-04-27T21:30:00"
+                          },
+                          "timestamp": "2026-04-27T21:30:00"
+                        }
+                        """)))
+    })
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @PathVariable Long postId, @RequestBody @Valid CommentCreateRequest request) {
+        // TODO: 실제 서비스 연동
+        CommentResponse.MonsterInfo monster = new CommentResponse.MonsterInfo(70, 100, "ALIVE");
+        CommentResponse response =
+                new CommentResponse(1L, postId, request.content(), monster, LocalDateTime.now());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok("댓글이 작성되었습니다.", response));
+    }
+
+    @Operation(summary = "댓글 목록 조회")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "댓글 목록 조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "댓글 목록을 조회했습니다.",
+                          "data": {
+                            "comments": [
+                              {
+                                "commentId": 1,
+                                "authorNickname": "anonymous",
+                                "content": "지금 많이 힘들겠지만, 여기까지 온 것만으로도 충분히 잘하고 있어요.",
+                                "createdAt": "2026-04-27T21:30:00"
+                              }
+                            ],
+                            "nextCursor": null
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @GetMapping("/posts/{postId}/comments")
+    public ApiResponse<CommentListResponse> getComments(
+            @PathVariable Long postId,
+            @Parameter(description = "커서 (마지막 commentId)") @RequestParam(required = false)
+                    Long cursor,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
+        // TODO: 실제 서비스 연동
+        CommentListResponse.CommentSummary summary =
+                new CommentListResponse.CommentSummary(
+                        1L,
+                        "anonymous",
+                        "지금 많이 힘들겠지만, 여기까지 온 것만으로도 충분히 잘하고 있어요.",
+                        LocalDateTime.now());
+        return ApiResponse.ok("댓글 목록을 조회했습니다.", new CommentListResponse(List.of(summary), null));
+    }
+
+    @Operation(summary = "댓글 삭제")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "댓글 삭제 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "댓글이 삭제되었습니다.",
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @DeleteMapping("/comments/{commentId}")
+    public ApiResponse<Void> deleteComment(@PathVariable Long commentId) {
+        // TODO: 실제 서비스 연동
+        return ApiResponse.ok("댓글이 삭제되었습니다.", null);
+    }
+}

--- a/src/main/java/com/ddd/webbb/comment/interfaces/dto/CommentCreateRequest.java
+++ b/src/main/java/com/ddd/webbb/comment/interfaces/dto/CommentCreateRequest.java
@@ -1,0 +1,9 @@
+package com.ddd.webbb.comment.interfaces.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentCreateRequest(
+        @Schema(example = "지금 많이 힘들겠지만, 여기까지 온 것만으로도 충분히 잘하고 있어요.")
+                @NotBlank(message = "댓글 내용은 필수입니다.")
+                String content) {}

--- a/src/main/java/com/ddd/webbb/comment/interfaces/dto/CommentListResponse.java
+++ b/src/main/java/com/ddd/webbb/comment/interfaces/dto/CommentListResponse.java
@@ -1,0 +1,10 @@
+package com.ddd.webbb.comment.interfaces.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CommentListResponse(List<CommentSummary> comments, Long nextCursor) {
+
+    public record CommentSummary(
+            Long commentId, String authorNickname, String content, LocalDateTime createdAt) {}
+}

--- a/src/main/java/com/ddd/webbb/comment/interfaces/dto/CommentResponse.java
+++ b/src/main/java/com/ddd/webbb/comment/interfaces/dto/CommentResponse.java
@@ -1,0 +1,9 @@
+package com.ddd.webbb.comment.interfaces.dto;
+
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        Long commentId, Long postId, String content, MonsterInfo monster, LocalDateTime createdAt) {
+
+    public record MonsterInfo(int hp, int maxHp, String status) {}
+}

--- a/src/main/java/com/ddd/webbb/emotion/domain/PostEmotion.java
+++ b/src/main/java/com/ddd/webbb/emotion/domain/PostEmotion.java
@@ -17,9 +17,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 @Entity
-@Table(
-        name = "post_emotion",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
+@Table(name = "post_emotion", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
 public class PostEmotion extends BaseCreatedEntity {
 
     @Id

--- a/src/main/java/com/ddd/webbb/monster/domain/Monster.java
+++ b/src/main/java/com/ddd/webbb/monster/domain/Monster.java
@@ -17,9 +17,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 @Entity
-@Table(
-        name = "monster",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
+@Table(name = "monster", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
 public class Monster extends BaseEntity {
 
     @Id

--- a/src/main/java/com/ddd/webbb/mypage/interfaces/MyPageController.java
+++ b/src/main/java/com/ddd/webbb/mypage/interfaces/MyPageController.java
@@ -1,0 +1,137 @@
+package com.ddd.webbb.mypage.interfaces;
+
+import com.ddd.webbb.global.common.response.ApiResponse;
+import com.ddd.webbb.mypage.interfaces.dto.MonsterStatsResponse;
+import com.ddd.webbb.mypage.interfaces.dto.MyCommentResponse;
+import com.ddd.webbb.mypage.interfaces.dto.MyPostResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "MyPage", description = "마이페이지 API")
+@RestController
+@RequestMapping("/api/me")
+public class MyPageController {
+
+    @Operation(summary = "내가 작성한 게시글 목록 조회")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "내 게시글 목록 조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "내 게시글 목록을 조회했습니다.",
+                          "data": {
+                            "posts": [
+                              {
+                                "postId": 1,
+                                "contentPreview": "면접에서 계속 떨어져서 점점 자신감이...",
+                                "emotionType": "ANXIETY",
+                                "monsterStatus": "ALIVE",
+                                "createdAt": "2026-04-27T21:00:00"
+                              }
+                            ],
+                            "nextCursor": null
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @GetMapping("/posts")
+    public ApiResponse<MyPostResponse> getMyPosts(
+            @Parameter(description = "커서 (마지막 postId)") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
+        // TODO: 실제 서비스 연동
+        MyPostResponse.MyPost post =
+                new MyPostResponse.MyPost(
+                        1L, "면접에서 계속 떨어져서 점점 자신감이...", "ANXIETY", "ALIVE", LocalDateTime.now());
+        return ApiResponse.ok("내 게시글 목록을 조회했습니다.", new MyPostResponse(List.of(post), null));
+    }
+
+    @Operation(summary = "내가 작성한 댓글 목록 조회")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "내 댓글 목록 조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "내 댓글 목록을 조회했습니다.",
+                          "data": {
+                            "comments": [
+                              {
+                                "commentId": 1,
+                                "postId": 1,
+                                "content": "지금 많이 힘들겠지만, 여기까지 온 것만으로도 충분히 잘하고 있어요.",
+                                "createdAt": "2026-04-27T21:30:00"
+                              }
+                            ],
+                            "nextCursor": null
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @GetMapping("/comments")
+    public ApiResponse<MyCommentResponse> getMyComments(
+            @Parameter(description = "커서 (마지막 commentId)") @RequestParam(required = false)
+                    Long cursor,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
+        // TODO: 실제 서비스 연동
+        MyCommentResponse.MyComment comment =
+                new MyCommentResponse.MyComment(
+                        1L, 1L, "지금 많이 힘들겠지만, 여기까지 온 것만으로도 충분히 잘하고 있어요.", LocalDateTime.now());
+        return ApiResponse.ok("내 댓글 목록을 조회했습니다.", new MyCommentResponse(List.of(comment), null));
+    }
+
+    @Operation(summary = "몬스터 통계 조회")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "몬스터 통계 조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "몬스터 통계를 조회했습니다.",
+                          "data": {
+                            "totalMonsterCount": 5,
+                            "defeatedMonsterCount": 3,
+                            "mostFrequentEmotion": { "type": "ANXIETY", "displayName": "불안", "count": 3 }
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @GetMapping("/monster-stats")
+    public ApiResponse<MonsterStatsResponse> getMonsterStats() {
+        // TODO: 실제 서비스 연동
+        MonsterStatsResponse.MostFrequentEmotion emotion =
+                new MonsterStatsResponse.MostFrequentEmotion("ANXIETY", "불안", 3);
+        return ApiResponse.ok("몬스터 통계를 조회했습니다.", new MonsterStatsResponse(5, 3, emotion));
+    }
+}

--- a/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MonsterStatsResponse.java
+++ b/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MonsterStatsResponse.java
@@ -1,0 +1,7 @@
+package com.ddd.webbb.mypage.interfaces.dto;
+
+public record MonsterStatsResponse(
+        int totalMonsterCount, int defeatedMonsterCount, MostFrequentEmotion mostFrequentEmotion) {
+
+    public record MostFrequentEmotion(String type, String displayName, int count) {}
+}

--- a/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MyCommentResponse.java
+++ b/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MyCommentResponse.java
@@ -1,0 +1,9 @@
+package com.ddd.webbb.mypage.interfaces.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MyCommentResponse(List<MyComment> comments, Long nextCursor) {
+
+    public record MyComment(Long commentId, Long postId, String content, LocalDateTime createdAt) {}
+}

--- a/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MyPostResponse.java
+++ b/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MyPostResponse.java
@@ -1,0 +1,14 @@
+package com.ddd.webbb.mypage.interfaces.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MyPostResponse(List<MyPost> posts, Long nextCursor) {
+
+    public record MyPost(
+            Long postId,
+            String contentPreview,
+            String emotionType,
+            String monsterStatus,
+            LocalDateTime createdAt) {}
+}

--- a/src/main/java/com/ddd/webbb/post/interfaces/LikeController.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/LikeController.java
@@ -1,0 +1,80 @@
+package com.ddd.webbb.post.interfaces;
+
+import com.ddd.webbb.global.common.response.ApiResponse;
+import com.ddd.webbb.post.interfaces.dto.LikeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Like", description = "좋아요 API")
+@RestController
+@RequestMapping("/api/posts/{postId}/likes")
+public class LikeController {
+
+    @Operation(summary = "좋아요 등록")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "좋아요 등록 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "좋아요를 등록했습니다.",
+                          "data": {
+                            "postId": 1,
+                            "likeCount": 4,
+                            "monster": { "hp": 70, "maxHp": 100, "status": "ALIVE" }
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @PostMapping
+    public ApiResponse<LikeResponse> like(@PathVariable Long postId) {
+        // TODO: 실제 서비스 연동
+        LikeResponse.MonsterInfo monster = new LikeResponse.MonsterInfo(70, 100, "ALIVE");
+        return ApiResponse.ok("좋아요를 등록했습니다.", new LikeResponse(postId, 4, monster));
+    }
+
+    @Operation(summary = "좋아요 취소")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "좋아요 취소 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "좋아요를 취소했습니다.",
+                          "data": {
+                            "postId": 1,
+                            "likeCount": 3,
+                            "monster": { "hp": 80, "maxHp": 100, "status": "ALIVE" }
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @DeleteMapping("/me")
+    public ApiResponse<LikeResponse> unlike(@PathVariable Long postId) {
+        // TODO: 실제 서비스 연동
+        LikeResponse.MonsterInfo monster = new LikeResponse.MonsterInfo(80, 100, "ALIVE");
+        return ApiResponse.ok("좋아요를 취소했습니다.", new LikeResponse(postId, 3, monster));
+    }
+}

--- a/src/main/java/com/ddd/webbb/post/interfaces/PostController.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/PostController.java
@@ -1,0 +1,278 @@
+package com.ddd.webbb.post.interfaces;
+
+import com.ddd.webbb.global.common.response.ApiResponse;
+import com.ddd.webbb.post.interfaces.dto.PostCreateRequest;
+import com.ddd.webbb.post.interfaces.dto.PostDetailResponse;
+import com.ddd.webbb.post.interfaces.dto.PostListResponse;
+import com.ddd.webbb.post.interfaces.dto.PostResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Post", description = "게시글 API")
+@RestController
+@RequestMapping("/api/posts")
+public class PostController {
+
+    private static final PostResponse.AuthorInfo STUB_AUTHOR =
+            new PostResponse.AuthorInfo(
+                    "01939b10-7b0f-7c8f-9a2b-111111111111", "ogu", "DEVELOPMENT", "YEAR_3");
+
+    private static final PostResponse.EmotionInfo STUB_EMOTION =
+            new PostResponse.EmotionInfo("ANXIETY", "불안", "면접 불합격으로 인한 자신감 저하");
+
+    private static final PostResponse.MonsterInfo STUB_MONSTER =
+            new PostResponse.MonsterInfo("ANXIETY_MONSTER", 80, 100, "ALIVE");
+
+    @Operation(summary = "게시글 작성")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "201",
+                description = "게시글 작성 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "게시글이 작성되었습니다.",
+                          "data": {
+                            "postId": 1,
+                            "author": { "id": "01939b10-7b0f-7c8f-9a2b-111111111111", "nickname": "ogu", "jobRole": "DEVELOPMENT", "careerYear": "YEAR_3" },
+                            "content": "면접에서 계속 떨어져서 점점 자신감이 사라져요.",
+                            "commentTone": "COMFORT_ME",
+                            "emotion": { "type": "ANXIETY", "displayName": "불안", "summary": "면접 불합격으로 인한 자신감 저하" },
+                            "monster": { "type": "ANXIETY_MONSTER", "hp": 80, "maxHp": 100, "status": "ALIVE" },
+                            "likeCount": 0,
+                            "commentCount": 0,
+                            "createdAt": "2026-04-27T21:00:00"
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<PostResponse>> createPost(
+            @RequestBody @Valid PostCreateRequest request) {
+        // TODO: 실제 서비스 연동
+        PostResponse response =
+                new PostResponse(
+                        1L,
+                        STUB_AUTHOR,
+                        request.content(),
+                        request.commentTone(),
+                        STUB_EMOTION,
+                        STUB_MONSTER,
+                        0,
+                        0,
+                        LocalDateTime.now());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok("게시글이 작성되었습니다.", response));
+    }
+
+    @Operation(summary = "게시글 목록 조회")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "게시글 목록 조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "게시글 목록을 조회했습니다.",
+                          "data": {
+                            "posts": [
+                              {
+                                "postId": 1,
+                                "authorNickname": "ogu",
+                                "jobRole": "DEVELOPMENT",
+                                "careerYear": "YEAR_3",
+                                "contentPreview": "면접에서 계속 떨어져서 점점 자신감이...",
+                                "emotionType": "ANXIETY",
+                                "monster": { "type": "ANXIETY_MONSTER", "hp": 80, "maxHp": 100, "status": "ALIVE" },
+                                "likeCount": 3,
+                                "commentCount": 5,
+                                "createdAt": "2026-04-27T21:00:00"
+                              }
+                            ],
+                            "nextCursor": null
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @GetMapping
+    public ApiResponse<PostListResponse> getPosts(
+            @Parameter(description = "커서 (마지막 postId)") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
+        // TODO: 실제 서비스 연동
+        PostListResponse.MonsterInfo monsterInfo =
+                new PostListResponse.MonsterInfo("ANXIETY_MONSTER", 80, 100, "ALIVE");
+        PostListResponse.PostSummary summary =
+                new PostListResponse.PostSummary(
+                        1L,
+                        "ogu",
+                        "DEVELOPMENT",
+                        "YEAR_3",
+                        "면접에서 계속 떨어져서 점점 자신감이...",
+                        "ANXIETY",
+                        monsterInfo,
+                        3,
+                        5,
+                        LocalDateTime.now());
+        return ApiResponse.ok("게시글 목록을 조회했습니다.", new PostListResponse(List.of(summary), null));
+    }
+
+    @Operation(summary = "게시글 상세 조회")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "게시글 상세 조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "게시글을 조회했습니다.",
+                          "data": {
+                            "postId": 1,
+                            "author": { "id": "01939b10-7b0f-7c8f-9a2b-111111111111", "nickname": "ogu", "jobRole": "DEVELOPMENT", "careerYear": "YEAR_3" },
+                            "content": "면접에서 계속 떨어져서 점점 자신감이 사라져요.",
+                            "commentTone": "COMFORT_ME",
+                            "emotion": { "type": "ANXIETY", "displayName": "불안" },
+                            "monster": { "type": "ANXIETY_MONSTER", "hp": 80, "maxHp": 100, "status": "ALIVE" },
+                            "likeCount": 3,
+                            "commentCount": 1,
+                            "comments": [
+                              { "commentId": 1, "authorNickname": "anonymous", "content": "힘내세요!", "createdAt": "2026-04-27T21:30:00" }
+                            ],
+                            "createdAt": "2026-04-27T21:00:00"
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @GetMapping("/{postId}")
+    public ApiResponse<PostDetailResponse> getPost(@PathVariable Long postId) {
+        // TODO: 실제 서비스 연동
+        PostDetailResponse.AuthorInfo author =
+                new PostDetailResponse.AuthorInfo(
+                        "01939b10-7b0f-7c8f-9a2b-111111111111", "ogu", "DEVELOPMENT", "YEAR_3");
+        PostDetailResponse.EmotionInfo emotion =
+                new PostDetailResponse.EmotionInfo("ANXIETY", "불안");
+        PostDetailResponse.MonsterInfo monster =
+                new PostDetailResponse.MonsterInfo("ANXIETY_MONSTER", 80, 100, "ALIVE");
+        PostDetailResponse.CommentInfo comment =
+                new PostDetailResponse.CommentInfo(1L, "anonymous", "힘내세요!", LocalDateTime.now());
+        PostDetailResponse response =
+                new PostDetailResponse(
+                        postId,
+                        author,
+                        "면접에서 계속 떨어져서 점점 자신감이 사라져요.",
+                        "COMFORT_ME",
+                        emotion,
+                        monster,
+                        3,
+                        1,
+                        List.of(comment),
+                        LocalDateTime.now());
+        return ApiResponse.ok("게시글을 조회했습니다.", response);
+    }
+
+    @Operation(summary = "게시글 수정")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "게시글 수정 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "게시글이 수정되었습니다.",
+                          "data": {
+                            "postId": 1,
+                            "author": { "id": "01939b10-7b0f-7c8f-9a2b-111111111111", "nickname": "ogu", "jobRole": "DEVELOPMENT", "careerYear": "YEAR_3" },
+                            "content": "수정된 내용입니다.",
+                            "commentTone": "COMFORT_ME",
+                            "emotion": { "type": "ANXIETY", "displayName": "불안", "summary": "면접 불합격으로 인한 자신감 저하" },
+                            "monster": { "type": "ANXIETY_MONSTER", "hp": 80, "maxHp": 100, "status": "ALIVE" },
+                            "likeCount": 3,
+                            "commentCount": 5,
+                            "createdAt": "2026-04-27T21:00:00"
+                          },
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @PatchMapping("/{postId}")
+    public ApiResponse<PostResponse> updatePost(
+            @PathVariable Long postId, @RequestBody @Valid PostCreateRequest request) {
+        // TODO: 실제 서비스 연동
+        PostResponse response =
+                new PostResponse(
+                        postId,
+                        STUB_AUTHOR,
+                        request.content(),
+                        request.commentTone(),
+                        STUB_EMOTION,
+                        STUB_MONSTER,
+                        3,
+                        5,
+                        LocalDateTime.now());
+        return ApiResponse.ok("게시글이 수정되었습니다.", response);
+    }
+
+    @Operation(summary = "게시글 삭제")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "게시글 삭제 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "게시글이 삭제되었습니다.",
+                          "timestamp": "2026-04-27T21:00:00"
+                        }
+                        """)))
+    })
+    @DeleteMapping("/{postId}")
+    public ApiResponse<Void> deletePost(@PathVariable Long postId) {
+        // TODO: 실제 서비스 연동
+        return ApiResponse.ok("게시글이 삭제되었습니다.", null);
+    }
+}

--- a/src/main/java/com/ddd/webbb/post/interfaces/dto/LikeResponse.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/dto/LikeResponse.java
@@ -1,0 +1,6 @@
+package com.ddd.webbb.post.interfaces.dto;
+
+public record LikeResponse(Long postId, int likeCount, MonsterInfo monster) {
+
+    public record MonsterInfo(int hp, int maxHp, String status) {}
+}

--- a/src/main/java/com/ddd/webbb/post/interfaces/dto/PostCreateRequest.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/dto/PostCreateRequest.java
@@ -1,0 +1,9 @@
+package com.ddd.webbb.post.interfaces.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record PostCreateRequest(
+        @Schema(example = "면접에서 계속 떨어져서 점점 자신감이 사라져요.") @NotBlank(message = "게시글 내용은 필수입니다.")
+                String content,
+        @Schema(example = "COMFORT_ME") String commentTone) {}

--- a/src/main/java/com/ddd/webbb/post/interfaces/dto/PostDetailResponse.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/dto/PostDetailResponse.java
@@ -1,0 +1,26 @@
+package com.ddd.webbb.post.interfaces.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostDetailResponse(
+        Long postId,
+        AuthorInfo author,
+        String content,
+        String commentTone,
+        EmotionInfo emotion,
+        MonsterInfo monster,
+        int likeCount,
+        int commentCount,
+        List<CommentInfo> comments,
+        LocalDateTime createdAt) {
+
+    public record AuthorInfo(String id, String nickname, String jobRole, String careerYear) {}
+
+    public record EmotionInfo(String type, String displayName) {}
+
+    public record MonsterInfo(String type, int hp, int maxHp, String status) {}
+
+    public record CommentInfo(
+            Long commentId, String authorNickname, String content, LocalDateTime createdAt) {}
+}

--- a/src/main/java/com/ddd/webbb/post/interfaces/dto/PostListResponse.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/dto/PostListResponse.java
@@ -1,0 +1,21 @@
+package com.ddd.webbb.post.interfaces.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostListResponse(List<PostSummary> posts, Long nextCursor) {
+
+    public record PostSummary(
+            Long postId,
+            String authorNickname,
+            String jobRole,
+            String careerYear,
+            String contentPreview,
+            String emotionType,
+            MonsterInfo monster,
+            int likeCount,
+            int commentCount,
+            LocalDateTime createdAt) {}
+
+    public record MonsterInfo(String type, int hp, int maxHp, String status) {}
+}

--- a/src/main/java/com/ddd/webbb/post/interfaces/dto/PostResponse.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/dto/PostResponse.java
@@ -1,0 +1,21 @@
+package com.ddd.webbb.post.interfaces.dto;
+
+import java.time.LocalDateTime;
+
+public record PostResponse(
+        Long postId,
+        AuthorInfo author,
+        String content,
+        String commentTone,
+        EmotionInfo emotion,
+        MonsterInfo monster,
+        int likeCount,
+        int commentCount,
+        LocalDateTime createdAt) {
+
+    public record AuthorInfo(String id, String nickname, String jobRole, String careerYear) {}
+
+    public record EmotionInfo(String type, String displayName, String summary) {}
+
+    public record MonsterInfo(String type, int hp, int maxHp, String status) {}
+}

--- a/src/main/java/com/ddd/webbb/user/interfaces/UserController.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/UserController.java
@@ -4,6 +4,8 @@ import com.ddd.webbb.global.common.response.ApiResponse;
 import com.ddd.webbb.user.application.UserService;
 import com.ddd.webbb.user.interfaces.dto.UserCreateRequest;
 import com.ddd.webbb.user.interfaces.dto.UserListResponse;
+import com.ddd.webbb.user.interfaces.dto.UserMeResponse;
+import com.ddd.webbb.user.interfaces.dto.UserProfileUpdateRequest;
 import com.ddd.webbb.user.interfaces.dto.UserResponse;
 import com.ddd.webbb.user.interfaces.dto.UserUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -253,5 +256,118 @@ public class UserController {
     public ResponseEntity<Void> withdrawUser(@PathVariable UUID id) {
         userService.withdrawUser(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "내 정보 조회")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "요청이 성공했습니다.",
+                          "data": {
+                            "id": "550e8400-e29b-41d4-a716-446655440000",
+                            "email": "test@test.com",
+                            "nickname": "ogu",
+                            "jobRole": "BACKEND",
+                            "careerYear": "YEAR_3",
+                            "status": "ACTIVE",
+                            "createdAt": "2026-05-03T12:00:00"
+                          },
+                          "timestamp": "2026-05-03T12:00:00"
+                        }
+                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": false,
+                          "message": "인증이 필요합니다.",
+                          "timestamp": "2026-05-03T12:00:00"
+                        }
+                        """)))
+    })
+    @GetMapping("/me")
+    public ApiResponse<UserMeResponse> getMe() {
+        // TODO: 실제 서비스 연동
+        return ApiResponse.ok(
+                new UserMeResponse(
+                        "550e8400-e29b-41d4-a716-446655440000",
+                        "test@test.com",
+                        "ogu",
+                        "BACKEND",
+                        "YEAR_3",
+                        "ACTIVE",
+                        LocalDateTime.of(2026, 5, 3, 12, 0)));
+    }
+
+    @Operation(summary = "내 프로필 수정")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "수정 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "요청이 성공했습니다.",
+                          "data": {
+                            "id": "550e8400-e29b-41d4-a716-446655440000",
+                            "email": "test@test.com",
+                            "nickname": "newogu",
+                            "jobRole": "PLANNING",
+                            "careerYear": "YEAR_5",
+                            "status": "ACTIVE",
+                            "createdAt": "2026-05-03T12:00:00"
+                          },
+                          "timestamp": "2026-05-03T12:00:00"
+                        }
+                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": false,
+                          "message": "인증이 필요합니다.",
+                          "timestamp": "2026-05-03T12:00:00"
+                        }
+                        """)))
+    })
+    @PatchMapping("/me/profile")
+    public ApiResponse<UserMeResponse> updateMyProfile(
+            @RequestBody @Valid UserProfileUpdateRequest request) {
+        // TODO: 실제 서비스 연동
+        return ApiResponse.ok(
+                new UserMeResponse(
+                        "550e8400-e29b-41d4-a716-446655440000",
+                        "test@test.com",
+                        request.nickname() != null ? request.nickname() : "ogu",
+                        request.jobRole() != null ? request.jobRole() : "BACKEND",
+                        request.careerYear() != null ? request.careerYear() : "YEAR_3",
+                        "ACTIVE",
+                        LocalDateTime.of(2026, 5, 3, 12, 0)));
     }
 }

--- a/src/main/java/com/ddd/webbb/user/interfaces/UserController.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/UserController.java
@@ -276,9 +276,9 @@ public class UserController {
                             "id": "550e8400-e29b-41d4-a716-446655440000",
                             "email": "test@test.com",
                             "nickname": "ogu",
-                            "jobRole": "BACKEND",
-                            "careerYear": "YEAR_3",
-                            "status": "ACTIVE",
+                            "jobType": "BACKEND",
+                            "careerLevel": "3년차",
+                            "isActive": true,
                             "createdAt": "2026-05-03T12:00:00"
                           },
                           "timestamp": "2026-05-03T12:00:00"
@@ -305,12 +305,12 @@ public class UserController {
         // TODO: 실제 서비스 연동
         return ApiResponse.ok(
                 new UserMeResponse(
-                        "550e8400-e29b-41d4-a716-446655440000",
+                        UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
                         "test@test.com",
                         "ogu",
                         "BACKEND",
-                        "YEAR_3",
-                        "ACTIVE",
+                        "3년차",
+                        true,
                         LocalDateTime.of(2026, 5, 3, 12, 0)));
     }
 
@@ -332,9 +332,9 @@ public class UserController {
                             "id": "550e8400-e29b-41d4-a716-446655440000",
                             "email": "test@test.com",
                             "nickname": "newogu",
-                            "jobRole": "PLANNING",
-                            "careerYear": "YEAR_5",
-                            "status": "ACTIVE",
+                            "jobType": "PLANNING",
+                            "careerLevel": "5년차",
+                            "isActive": true,
                             "createdAt": "2026-05-03T12:00:00"
                           },
                           "timestamp": "2026-05-03T12:00:00"
@@ -362,12 +362,12 @@ public class UserController {
         // TODO: 실제 서비스 연동
         return ApiResponse.ok(
                 new UserMeResponse(
-                        "550e8400-e29b-41d4-a716-446655440000",
+                        UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
                         "test@test.com",
                         request.nickname() != null ? request.nickname() : "ogu",
-                        request.jobRole() != null ? request.jobRole() : "BACKEND",
-                        request.careerYear() != null ? request.careerYear() : "YEAR_3",
-                        "ACTIVE",
+                        request.jobType() != null ? request.jobType() : "BACKEND",
+                        request.careerLevel() != null ? request.careerLevel() : "3년차",
+                        true,
                         LocalDateTime.of(2026, 5, 3, 12, 0)));
     }
 }

--- a/src/main/java/com/ddd/webbb/user/interfaces/dto/UserMeResponse.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/dto/UserMeResponse.java
@@ -1,12 +1,13 @@
 package com.ddd.webbb.user.interfaces.dto;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record UserMeResponse(
-        String id,
+        UUID id,
         String email,
         String nickname,
-        String jobRole,
-        String careerYear,
-        String status,
+        String jobType,
+        String careerLevel,
+        boolean isActive,
         LocalDateTime createdAt) {}

--- a/src/main/java/com/ddd/webbb/user/interfaces/dto/UserMeResponse.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/dto/UserMeResponse.java
@@ -1,0 +1,12 @@
+package com.ddd.webbb.user.interfaces.dto;
+
+import java.time.LocalDateTime;
+
+public record UserMeResponse(
+        String id,
+        String email,
+        String nickname,
+        String jobRole,
+        String careerYear,
+        String status,
+        LocalDateTime createdAt) {}

--- a/src/main/java/com/ddd/webbb/user/interfaces/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/dto/UserProfileUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.ddd.webbb.user.interfaces.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+public record UserProfileUpdateRequest(
+        @Schema(example = "newogu") @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.") String nickname,
+        @Schema(example = "PLANNING") String jobRole,
+        @Schema(example = "YEAR_5") String careerYear) {}

--- a/src/main/java/com/ddd/webbb/user/interfaces/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/dto/UserProfileUpdateRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
 public record UserProfileUpdateRequest(
-        @Schema(example = "newogu") @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.") String nickname,
-        @Schema(example = "PLANNING") String jobRole,
-        @Schema(example = "YEAR_5") String careerYear) {}
+        @Schema(example = "newogu") @Size(min = 1, max = 10, message = "닉네임은 1자 이상 10자 이하여야 합니다.")
+                String nickname,
+        @Schema(example = "PLANNING") String jobType,
+        @Schema(example = "3년차") String careerLevel) {}


### PR DESCRIPTION
## Summary
- API 명세 기반으로 20개 스텁(깡통) 컨트롤러 구현
- 서비스 로직 없이 하드코딩 응답 반환, Swagger UI에서 전체 API 형태 확인 가능
- 기존 UserController에 `GET /api/users/me`, `PATCH /api/users/me/profile` 엔드포인트 추가

## 신규 컨트롤러
| 그룹 | 엔드포인트 | 수 |
|------|----------|---|
| Auth | `POST /api/auth/oauth/{provider}`, `signup/email`, `login/email`, `logout`, `refresh` | 5 |
| Post | `POST/GET/PATCH/DELETE /api/posts`, `GET /api/posts/{postId}` | 5 |
| Like | `POST /api/posts/{postId}/likes`, `DELETE .../likes/me` | 2 |
| Comment | `POST/GET /api/posts/{postId}/comments`, `DELETE /api/comments/{commentId}` | 3 |
| MyPage | `GET /api/me/posts`, `me/comments`, `me/monster-stats` | 3 |
| User 확장 | `GET /api/users/me`, `PATCH /api/users/me/profile` | 2 |

## 구현 방식
- record DTO + `ApiResponse<T>` 래퍼 + `@Tag`/`@Operation` Swagger 어노테이션
- 각 메서드에 `// TODO: 실제 서비스 연동` 주석

## Test plan
- [x] `./gradlew spotlessCheck` 통과
- [x] `./gradlew :test` 통과
- [ ] 서버 기동 후 Swagger UI(`/swagger-ui/index.html`)에서 전체 API 확인

closes #16