### PR TITLE
OpenAPI(Swagger) 설정 보강

### DIFF
--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/application/RetrospectiveService.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/application/RetrospectiveService.java
@@ -26,7 +26,8 @@ public class RetrospectiveService {
         try {
             KptAnalysis analysis = analyzer.analyze(context);
             if (analysis.isEmpty()) {
-                return new RetrospectiveResult.Failure(ErrorCode.EMPTY_RESPONSE, "AI returned empty analysis");
+                return new RetrospectiveResult.Failure(
+                        ErrorCode.EMPTY_RESPONSE, "AI returned empty analysis");
             }
             return new RetrospectiveResult.Success(analysis);
         } catch (RetrospectiveGenerationException e) {

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiConfig.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiConfig.java
@@ -1,5 +1,9 @@
 package com.dnd.poc.retrospective.config;
 
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,11 +13,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
-
-import java.io.IOException;
-import java.net.http.HttpClient;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 
 @Configuration
 @EnableConfigurationProperties(AiProperties.class)
@@ -45,7 +44,8 @@ public class AiConfig {
 
     @Bean
     @ConditionalOnExpression(LIVE_KEY_CONDITION)
-    public KptSystemPrompt kptSystemPrompt(AiProperties props, ResourceLoader loader) throws IOException {
+    public KptSystemPrompt kptSystemPrompt(AiProperties props, ResourceLoader loader)
+            throws IOException {
         Resource resource = loader.getResource(props.promptLocation());
         try (var in = resource.getInputStream()) {
             return new KptSystemPrompt(new String(in.readAllBytes(), StandardCharsets.UTF_8));

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiProperties.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiProperties.java
@@ -3,15 +3,10 @@ package com.dnd.poc.retrospective.config;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import java.time.Duration;
-
 @Validated
 @ConfigurationProperties(prefix = "retrospective.ai")
-public record AiProperties(
-        @NotBlank String promptLocation,
-        @NotNull @Positive Duration timeout
-) {
-}
+public record AiProperties(@NotBlank String promptLocation, @NotNull @Positive Duration timeout) {}

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/OpenApiConfig.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/OpenApiConfig.java
@@ -12,11 +12,18 @@ class OpenApiConfig {
 
     @Bean
     OpenAPI retrospectiveOpenApi() {
-        return new OpenAPI().info(new Info()
-                .title("Retrospective AI API")
-                .version("0.0.1")
-                .description("취준생의 감정 텍스트를 KPT(Keep/Problem/Try) + 응원 메시지로 구조화하는 AI 회고 도우미.")
-                .contact(new Contact().name("DDD-13 WEBBB").url("https://github.com/DDD-Community/DDD-13-WEBBB_BE"))
-                .license(new License().name("Internal PoC")));
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("Retrospective AI API")
+                                .version("0.0.1")
+                                .description(
+                                        "취준생의 감정 텍스트를 KPT(Keep/Problem/Try) + 응원 메시지로 구조화하는 AI 회고 도우미.")
+                                .contact(
+                                        new Contact()
+                                                .name("DDD-13 WEBBB")
+                                                .url(
+                                                        "https://github.com/DDD-Community/DDD-13-WEBBB_BE"))
+                                .license(new License().name("Internal PoC")));
     }
 }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/domain/KptAnalysis.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/domain/KptAnalysis.java
@@ -4,11 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 public record KptAnalysis(
-        List<String> keep,
-        List<String> problem,
-        List<String> tries,
-        String cheerMessage
-) {
+        List<String> keep, List<String> problem, List<String> tries, String cheerMessage) {
     public KptAnalysis {
         Objects.requireNonNull(keep, "keep must not be null");
         Objects.requireNonNull(problem, "problem must not be null");

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/FallbackKptAnalyzer.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/FallbackKptAnalyzer.java
@@ -4,30 +4,26 @@ import com.dnd.poc.retrospective.application.port.KptAnalyzer;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.dnd.poc.retrospective.domain.RetrospectiveContext;
 import com.dnd.poc.retrospective.domain.exception.RetryableUpstreamException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 /**
- * 다중 모델 안정성을 위한 Fallback 어댑터입니다.
- * 실서비스 시나리오에서 주 모델(OpenAI) 장애 시 보조 모델이나 Mock으로 전환하여 서비스 가용성을 보장합니다.
+ * 다중 모델 안정성을 위한 Fallback 어댑터입니다. 실서비스 시나리오에서 주 모델(OpenAI) 장애 시 보조 모델이나 Mock으로 전환하여 서비스 가용성을 보장합니다.
  */
 @Primary
 @Component
 class FallbackKptAnalyzer implements KptAnalyzer {
 
     private static final Logger log = LoggerFactory.getLogger(FallbackKptAnalyzer.class);
-    
+
     private final List<KptAnalyzer> analyzers;
 
     FallbackKptAnalyzer(List<KptAnalyzer> analyzers) {
         // FallbackKptAnalyzer 자체를 제외한 나머지 분석기들을 수집
-        this.analyzers = analyzers.stream()
-                .filter(a -> a != this)
-                .toList();
+        this.analyzers = analyzers.stream().filter(a -> a != this).toList();
     }
 
     @Override
@@ -39,8 +35,10 @@ class FallbackKptAnalyzer implements KptAnalyzer {
                 log.info("Attempting analysis with: {}", analyzer.getClass().getSimpleName());
                 return analyzer.analyze(context);
             } catch (RetryableUpstreamException e) {
-                log.warn("Analyzer {} failed, trying next. error={}", 
-                        analyzer.getClass().getSimpleName(), e.getMessage());
+                log.warn(
+                        "Analyzer {} failed, trying next. error={}",
+                        analyzer.getClass().getSimpleName(),
+                        e.getMessage());
                 lastException = e;
             }
         }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/KptResponse.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/KptResponse.java
@@ -1,13 +1,10 @@
 package com.dnd.poc.retrospective.infrastructure.ai;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 record KptResponse(
         List<String> keep,
         List<String> problem,
         @JsonProperty("try") List<String> tries,
-        @JsonProperty("cheer_message") String cheerMessage
-) {
-}
+        @JsonProperty("cheer_message") String cheerMessage) {}

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/MockKptAnalyzer.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/MockKptAnalyzer.java
@@ -5,12 +5,11 @@ import com.dnd.poc.retrospective.config.AiConfig;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.dnd.poc.retrospective.domain.RetrospectiveContext;
 import jakarta.annotation.PostConstruct;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @ConditionalOnExpression(AiConfig.MOCK_KEY_CONDITION)
@@ -30,20 +29,10 @@ class MockKptAnalyzer implements KptAnalyzer {
     public KptAnalysis analyze(RetrospectiveContext context) {
         log.debug("Mock analyze invoked. length={}", context.length());
         return new KptAnalysis(
-                List.of(
-                        "끝까지 자리에 앉아 시도를 멈추지 않은 점",
-                        "본인 부족한 부분을 솔직히 인지하고 표현한 점"
-                ),
-                List.of(
-                        "시간 분배 전략이 정해져 있지 않음",
-                        "어려운 문제에서 손을 떼는 시점을 정해두지 않음"
-                ),
-                List.of(
-                        "내일 30분 동안 약점 영역 1챕터 복습하기",
-                        "타이머 두고 1문제 25분 룰 적용해보기"
-                ),
-                "오늘도 시도한 것만으로 충분히 잘하고 계세요. 한 걸음씩 가요."
-        );
+                List.of("끝까지 자리에 앉아 시도를 멈추지 않은 점", "본인 부족한 부분을 솔직히 인지하고 표현한 점"),
+                List.of("시간 분배 전략이 정해져 있지 않음", "어려운 문제에서 손을 떼는 시점을 정해두지 않음"),
+                List.of("내일 30분 동안 약점 영역 1챕터 복습하기", "타이머 두고 1문제 25분 룰 적용해보기"),
+                "오늘도 시도한 것만으로 충분히 잘하고 계세요. 한 걸음씩 가요.");
     }
 
     @Override

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/SpringAiKptAnalyzer.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/SpringAiKptAnalyzer.java
@@ -1,6 +1,7 @@
 package com.dnd.poc.retrospective.infrastructure.ai;
 
 import com.dnd.poc.retrospective.application.port.KptAnalyzer;
+import com.dnd.poc.retrospective.config.AiConfig;
 import com.dnd.poc.retrospective.config.AiConfig.KptSystemPrompt;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.dnd.poc.retrospective.domain.RetrospectiveContext;
@@ -11,18 +12,16 @@ import com.dnd.poc.retrospective.domain.exception.RetryableUpstreamException;
 import com.fasterxml.jackson.core.JacksonException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.dnd.poc.retrospective.config.AiConfig;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClientException;
-
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.net.http.HttpTimeoutException;
 import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 
 @Component
 @ConditionalOnExpression(AiConfig.LIVE_KEY_CONDITION)
@@ -95,11 +94,7 @@ class SpringAiKptAnalyzer implements KptAnalyzer {
         }
         try {
             return new KptAnalysis(
-                    response.keep(),
-                    response.problem(),
-                    response.tries(),
-                    response.cheerMessage()
-            );
+                    response.keep(), response.problem(), response.tries(), response.cheerMessage());
         } catch (NullPointerException | IllegalArgumentException e) {
             throw new PermanentResponseException(
                     ErrorCode.INVALID_RESPONSE, "AI response invalid: " + e.getMessage(), e);

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/CorrelationIdFilter.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/CorrelationIdFilter.java
@@ -4,14 +4,13 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.UUID;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -21,9 +20,9 @@ class CorrelationIdFilter extends OncePerRequestFilter {
     private static final String MDC_KEY = "correlationId";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain chain) throws ServletException, IOException {
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
         String id = request.getHeader(HEADER);
         if (id == null || id.isBlank()) {
             id = UUID.randomUUID().toString();

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/RetrospectiveController.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/RetrospectiveController.java
@@ -5,7 +5,6 @@ import com.dnd.poc.retrospective.domain.RetrospectiveContext;
 import com.dnd.poc.retrospective.domain.RetrospectiveResult;
 import com.dnd.poc.retrospective.domain.RetrospectiveResult.Failure;
 import com.dnd.poc.retrospective.domain.RetrospectiveResult.Success;
-import com.dnd.poc.retrospective.domain.exception.RetrospectiveGenerationException;
 import com.dnd.poc.retrospective.interfaces.dto.RetrospectiveRequest;
 import com.dnd.poc.retrospective.interfaces.dto.RetrospectiveResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,24 +35,43 @@ public class RetrospectiveController {
 
     @Operation(
             summary = "KPT 회고 분석",
-            description = "취준생의 텍스트를 KPT(Keep/Problem/Try) 프레임워크와 응원 메시지로 구조화해 반환합니다."
-    )
+            description = "취준생의 텍스트를 KPT(Keep/Problem/Try) 프레임워크와 응원 메시지로 구조화해 반환합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "분석 성공",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = RetrospectiveResponse.class))),
-            @ApiResponse(responseCode = "400", description = "입력 검증 실패 (빈 값 / 2000자 초과)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class))),
-            @ApiResponse(responseCode = "422", description = "AI 응답이 빈/잘못된 형식 (EMPTY_RESPONSE, INVALID_RESPONSE)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class))),
-            @ApiResponse(responseCode = "502", description = "업스트림 LLM 호출 실패 (UPSTREAM_UNAVAILABLE)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class))),
-            @ApiResponse(responseCode = "504", description = "업스트림 LLM 타임아웃 (UPSTREAM_TIMEOUT)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class)))
+        @ApiResponse(
+                responseCode = "200",
+                description = "분석 성공",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                schema = @Schema(implementation = RetrospectiveResponse.class))),
+        @ApiResponse(
+                responseCode = "400",
+                description = "입력 검증 실패 (빈 값 / 2000자 초과)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "AI 응답이 빈/잘못된 형식 (EMPTY_RESPONSE, INVALID_RESPONSE)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class))),
+        @ApiResponse(
+                responseCode = "502",
+                description = "업스트림 LLM 호출 실패 (UPSTREAM_UNAVAILABLE)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class))),
+        @ApiResponse(
+                responseCode = "504",
+                description = "업스트림 LLM 타임아웃 (UPSTREAM_TIMEOUT)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class)))
     })
     @PostMapping(value = "/analyze", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> analyze(@Valid @RequestBody RetrospectiveRequest request) {
@@ -62,9 +80,11 @@ public class RetrospectiveController {
         return switch (result) {
             case Success s -> ResponseEntity.ok(RetrospectiveResponse.from(s.analysis()));
             case Failure f -> {
-                ProblemDetail pd = ProblemDetail.forStatusAndDetail(
-                        org.springframework.http.HttpStatusCode.valueOf(f.code().getHttpStatus()),
-                        "AI 회고 생성에 실패했습니다.");
+                ProblemDetail pd =
+                        ProblemDetail.forStatusAndDetail(
+                                org.springframework.http.HttpStatusCode.valueOf(
+                                        f.code().getHttpStatus()),
+                                "AI 회고 생성에 실패했습니다.");
                 pd.setProperty("errorCode", f.code().name());
                 yield ResponseEntity.status(f.code().getHttpStatus()).body(pd);
             }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveRequest.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveRequest.java
@@ -8,14 +8,11 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "회고 분석 요청")
 public record RetrospectiveRequest(
         @Schema(
-                description = "사용자가 작성한 회고 원문 (1~2000자)",
-                example = "오늘 코테에서 시간이 부족해서 마지막 문제를 못 풀었어요. 자료구조 공부가 부족했던 것 같아요.",
-                minLength = 1,
-                maxLength = RetrospectiveContext.MAX_LENGTH,
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        @NotBlank(message = "context must not be blank")
-        @Size(max = RetrospectiveContext.MAX_LENGTH, message = "context too long")
-        String context
-) {
-}
+                        description = "사용자가 작성한 회고 원문 (1~2000자)",
+                        example = "오늘 코테에서 시간이 부족해서 마지막 문제를 못 풀었어요. 자료구조 공부가 부족했던 것 같아요.",
+                        minLength = 1,
+                        maxLength = RetrospectiveContext.MAX_LENGTH,
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                @NotBlank(message = "context must not be blank")
+                @Size(max = RetrospectiveContext.MAX_LENGTH, message = "context too long")
+                String context) {}

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveResponse.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveResponse.java
@@ -3,29 +3,21 @@ package com.dnd.poc.retrospective.interfaces.dto;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 @Schema(description = "KPT 분석 결과")
 public record RetrospectiveResponse(
         @Schema(description = "잘하고 있는 점", example = "[\"끝까지 시도한 점\",\"본인 약점을 객관화한 점\"]")
-        List<String> keep,
-
-        @Schema(description = "객관적·개선 가능한 사실", example = "[\"시간 분배 전략 부재\"]")
-        List<String> problem,
-
+                List<String> keep,
+        @Schema(description = "객관적·개선 가능한 사실", example = "[\"시간 분배 전략 부재\"]") List<String> problem,
         @Schema(description = "내일 실행할 수 있는 작은 액션", example = "[\"자료구조 30분 복습\"]")
-        @JsonProperty("try") List<String> tries,
-
+                @JsonProperty("try")
+                List<String> tries,
         @Schema(description = "따뜻한 위로·응원 한마디", example = "오늘도 시도한 것만으로 충분해요.")
-        @JsonProperty("cheer_message") String cheerMessage
-) {
+                @JsonProperty("cheer_message")
+                String cheerMessage) {
     public static RetrospectiveResponse from(KptAnalysis analysis) {
         return new RetrospectiveResponse(
-                analysis.keep(),
-                analysis.problem(),
-                analysis.tries(),
-                analysis.cheerMessage()
-        );
+                analysis.keep(), analysis.problem(), analysis.tries(), analysis.cheerMessage());
     }
 }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/exception/GlobalExceptionHandler.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.dnd.poc.retrospective.interfaces.exception;
 
 import com.dnd.poc.retrospective.domain.RetrospectiveResult.ErrorCode;
 import com.dnd.poc.retrospective.domain.exception.RetrospectiveGenerationException;
+import java.net.URI;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -9,9 +11,6 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.net.URI;
-import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -33,9 +32,10 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ProblemDetail handleValidation(MethodArgumentNotValidException e) {
-        String detail = e.getBindingResult().getFieldErrors().stream()
-                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
-                .collect(Collectors.joining(", "));
+        String detail =
+                e.getBindingResult().getFieldErrors().stream()
+                        .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                        .collect(Collectors.joining(", "));
         ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail);
         pd.setTitle("Validation failed");
         pd.setType(TYPE_VALIDATION);

--- a/src/main/java/com/ddd/webbb/emotion/domain/PostEmotion.java
+++ b/src/main/java/com/ddd/webbb/emotion/domain/PostEmotion.java
@@ -17,9 +17,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 @Entity
-@Table(
-        name = "post_emotion",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
+@Table(name = "post_emotion", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
 public class PostEmotion extends BaseCreatedEntity {
 
     @Id

--- a/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
@@ -7,16 +7,27 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.ArrayList;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    @Value("${spring.profiles.active:local}")
+    private String activeProfile;
+
     @Bean
     public OpenAPI openAPI() {
         String securitySchemeName = "bearerAuth";
+
+        List<Server> servers = new ArrayList<>();
+        servers.add(new Server().url("http://localhost:8080").description("Local"));
+        if ("prod".equals(activeProfile)) {
+            servers.add(new Server().url("https://api.webbb.site").description("Production"));
+        }
 
         return new OpenAPI()
                 .info(
@@ -29,12 +40,7 @@ public class SwaggerConfig {
                                                 .name("DDD-13 WEBBB")
                                                 .url(
                                                         "https://github.com/DDD-Community/DDD-13-WEBBB_BE")))
-                .servers(
-                        List.of(
-                                new Server().url("http://localhost:8080").description("Local"),
-                                new Server()
-                                        .url("https://api.webbb.site")
-                                        .description("Production")))
+                .servers(servers)
                 .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
                 .components(
                         new Components()

--- a/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
@@ -2,9 +2,12 @@ package com.ddd.webbb.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,7 +19,22 @@ public class SwaggerConfig {
         String securitySchemeName = "bearerAuth";
 
         return new OpenAPI()
-                .info(new Info().title("WEBBB API").description("WEBBB 백엔드 API 문서").version("v1"))
+                .info(
+                        new Info()
+                                .title("WEBBB API")
+                                .description("WEBBB 백엔드 API 문서")
+                                .version("v1")
+                                .contact(
+                                        new Contact()
+                                                .name("DDD-13 WEBBB")
+                                                .url(
+                                                        "https://github.com/DDD-Community/DDD-13-WEBBB_BE")))
+                .servers(
+                        List.of(
+                                new Server().url("http://localhost:8080").description("Local"),
+                                new Server()
+                                        .url("https://api.webbb.site")
+                                        .description("Production")))
                 .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
                 .components(
                         new Components()

--- a/src/main/java/com/ddd/webbb/monster/domain/Monster.java
+++ b/src/main/java/com/ddd/webbb/monster/domain/Monster.java
@@ -17,9 +17,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 @Entity
-@Table(
-        name = "monster",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
+@Table(name = "monster", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
 public class Monster extends BaseEntity {
 
     @Id

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,6 +19,12 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
 
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,14 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
     show-sql: false
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui/index.html
+    tags-sorter: alpha
+    operations-sorter: method
+    display-request-duration: true
+  api-docs:
+    path: /v3/api-docs
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json


### PR DESCRIPTION
## Summary
- SwaggerConfig에 서버 URL(Local/Production), 연락처 정보 추가
- springdoc 프로퍼티 설정 (태그 알파벳 정렬, 메서드별 정렬, 요청 소요시간 표시)
- prod 환경에서 Swagger UI / api-docs 비활성화 (보안)
- poc/juneseok, 엔티티 파일 spotless 포맷팅 적용

## 변경사항
| 파일 | 내용 |
|------|------|
| `SwaggerConfig.java` | Server URL, Contact 정보 추가 |
| `application.yml` | springdoc 프로퍼티 (정렬, 미디어타입, 요청 소요시간) |
| `application-prod.yml` | swagger-ui, api-docs 비활성화 |
| `poc/juneseok/**` | spotless 포맷팅 적용 |

## Test plan
- [x] `./gradlew spotlessCheck` 통과
- [x] `./gradlew :test` 통과
- [ ] 서버 기동 후 Swagger UI에서 서버 셀렉터, 태그 정렬 확인

closes #19