### PR TITLE
로깅 설정 추가 (Logback + MDC 필터)

### DIFF
--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/application/RetrospectiveService.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/application/RetrospectiveService.java
@@ -26,7 +26,8 @@ public class RetrospectiveService {
         try {
             KptAnalysis analysis = analyzer.analyze(context);
             if (analysis.isEmpty()) {
-                return new RetrospectiveResult.Failure(ErrorCode.EMPTY_RESPONSE, "AI returned empty analysis");
+                return new RetrospectiveResult.Failure(
+                        ErrorCode.EMPTY_RESPONSE, "AI returned empty analysis");
             }
             return new RetrospectiveResult.Success(analysis);
         } catch (RetrospectiveGenerationException e) {

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiConfig.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiConfig.java
@@ -1,5 +1,9 @@
 package com.dnd.poc.retrospective.config;
 
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,11 +13,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
-
-import java.io.IOException;
-import java.net.http.HttpClient;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 
 @Configuration
 @EnableConfigurationProperties(AiProperties.class)
@@ -45,7 +44,8 @@ public class AiConfig {
 
     @Bean
     @ConditionalOnExpression(LIVE_KEY_CONDITION)
-    public KptSystemPrompt kptSystemPrompt(AiProperties props, ResourceLoader loader) throws IOException {
+    public KptSystemPrompt kptSystemPrompt(AiProperties props, ResourceLoader loader)
+            throws IOException {
         Resource resource = loader.getResource(props.promptLocation());
         try (var in = resource.getInputStream()) {
             return new KptSystemPrompt(new String(in.readAllBytes(), StandardCharsets.UTF_8));

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiProperties.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/AiProperties.java
@@ -3,15 +3,10 @@ package com.dnd.poc.retrospective.config;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import java.time.Duration;
-
 @Validated
 @ConfigurationProperties(prefix = "retrospective.ai")
-public record AiProperties(
-        @NotBlank String promptLocation,
-        @NotNull @Positive Duration timeout
-) {
-}
+public record AiProperties(@NotBlank String promptLocation, @NotNull @Positive Duration timeout) {}

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/OpenApiConfig.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/config/OpenApiConfig.java
@@ -12,11 +12,18 @@ class OpenApiConfig {
 
     @Bean
     OpenAPI retrospectiveOpenApi() {
-        return new OpenAPI().info(new Info()
-                .title("Retrospective AI API")
-                .version("0.0.1")
-                .description("취준생의 감정 텍스트를 KPT(Keep/Problem/Try) + 응원 메시지로 구조화하는 AI 회고 도우미.")
-                .contact(new Contact().name("DDD-13 WEBBB").url("https://github.com/DDD-Community/DDD-13-WEBBB_BE"))
-                .license(new License().name("Internal PoC")));
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("Retrospective AI API")
+                                .version("0.0.1")
+                                .description(
+                                        "취준생의 감정 텍스트를 KPT(Keep/Problem/Try) + 응원 메시지로 구조화하는 AI 회고 도우미.")
+                                .contact(
+                                        new Contact()
+                                                .name("DDD-13 WEBBB")
+                                                .url(
+                                                        "https://github.com/DDD-Community/DDD-13-WEBBB_BE"))
+                                .license(new License().name("Internal PoC")));
     }
 }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/domain/KptAnalysis.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/domain/KptAnalysis.java
@@ -4,11 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 public record KptAnalysis(
-        List<String> keep,
-        List<String> problem,
-        List<String> tries,
-        String cheerMessage
-) {
+        List<String> keep, List<String> problem, List<String> tries, String cheerMessage) {
     public KptAnalysis {
         Objects.requireNonNull(keep, "keep must not be null");
         Objects.requireNonNull(problem, "problem must not be null");

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/FallbackKptAnalyzer.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/FallbackKptAnalyzer.java
@@ -4,30 +4,26 @@ import com.dnd.poc.retrospective.application.port.KptAnalyzer;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.dnd.poc.retrospective.domain.RetrospectiveContext;
 import com.dnd.poc.retrospective.domain.exception.RetryableUpstreamException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 /**
- * 다중 모델 안정성을 위한 Fallback 어댑터입니다.
- * 실서비스 시나리오에서 주 모델(OpenAI) 장애 시 보조 모델이나 Mock으로 전환하여 서비스 가용성을 보장합니다.
+ * 다중 모델 안정성을 위한 Fallback 어댑터입니다. 실서비스 시나리오에서 주 모델(OpenAI) 장애 시 보조 모델이나 Mock으로 전환하여 서비스 가용성을 보장합니다.
  */
 @Primary
 @Component
 class FallbackKptAnalyzer implements KptAnalyzer {
 
     private static final Logger log = LoggerFactory.getLogger(FallbackKptAnalyzer.class);
-    
+
     private final List<KptAnalyzer> analyzers;
 
     FallbackKptAnalyzer(List<KptAnalyzer> analyzers) {
         // FallbackKptAnalyzer 자체를 제외한 나머지 분석기들을 수집
-        this.analyzers = analyzers.stream()
-                .filter(a -> a != this)
-                .toList();
+        this.analyzers = analyzers.stream().filter(a -> a != this).toList();
     }
 
     @Override
@@ -39,8 +35,10 @@ class FallbackKptAnalyzer implements KptAnalyzer {
                 log.info("Attempting analysis with: {}", analyzer.getClass().getSimpleName());
                 return analyzer.analyze(context);
             } catch (RetryableUpstreamException e) {
-                log.warn("Analyzer {} failed, trying next. error={}", 
-                        analyzer.getClass().getSimpleName(), e.getMessage());
+                log.warn(
+                        "Analyzer {} failed, trying next. error={}",
+                        analyzer.getClass().getSimpleName(),
+                        e.getMessage());
                 lastException = e;
             }
         }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/KptResponse.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/KptResponse.java
@@ -1,13 +1,10 @@
 package com.dnd.poc.retrospective.infrastructure.ai;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 record KptResponse(
         List<String> keep,
         List<String> problem,
         @JsonProperty("try") List<String> tries,
-        @JsonProperty("cheer_message") String cheerMessage
-) {
-}
+        @JsonProperty("cheer_message") String cheerMessage) {}

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/MockKptAnalyzer.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/MockKptAnalyzer.java
@@ -5,12 +5,11 @@ import com.dnd.poc.retrospective.config.AiConfig;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.dnd.poc.retrospective.domain.RetrospectiveContext;
 import jakarta.annotation.PostConstruct;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @ConditionalOnExpression(AiConfig.MOCK_KEY_CONDITION)
@@ -30,20 +29,10 @@ class MockKptAnalyzer implements KptAnalyzer {
     public KptAnalysis analyze(RetrospectiveContext context) {
         log.debug("Mock analyze invoked. length={}", context.length());
         return new KptAnalysis(
-                List.of(
-                        "끝까지 자리에 앉아 시도를 멈추지 않은 점",
-                        "본인 부족한 부분을 솔직히 인지하고 표현한 점"
-                ),
-                List.of(
-                        "시간 분배 전략이 정해져 있지 않음",
-                        "어려운 문제에서 손을 떼는 시점을 정해두지 않음"
-                ),
-                List.of(
-                        "내일 30분 동안 약점 영역 1챕터 복습하기",
-                        "타이머 두고 1문제 25분 룰 적용해보기"
-                ),
-                "오늘도 시도한 것만으로 충분히 잘하고 계세요. 한 걸음씩 가요."
-        );
+                List.of("끝까지 자리에 앉아 시도를 멈추지 않은 점", "본인 부족한 부분을 솔직히 인지하고 표현한 점"),
+                List.of("시간 분배 전략이 정해져 있지 않음", "어려운 문제에서 손을 떼는 시점을 정해두지 않음"),
+                List.of("내일 30분 동안 약점 영역 1챕터 복습하기", "타이머 두고 1문제 25분 룰 적용해보기"),
+                "오늘도 시도한 것만으로 충분히 잘하고 계세요. 한 걸음씩 가요.");
     }
 
     @Override

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/SpringAiKptAnalyzer.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/infrastructure/ai/SpringAiKptAnalyzer.java
@@ -1,6 +1,7 @@
 package com.dnd.poc.retrospective.infrastructure.ai;
 
 import com.dnd.poc.retrospective.application.port.KptAnalyzer;
+import com.dnd.poc.retrospective.config.AiConfig;
 import com.dnd.poc.retrospective.config.AiConfig.KptSystemPrompt;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.dnd.poc.retrospective.domain.RetrospectiveContext;
@@ -11,18 +12,16 @@ import com.dnd.poc.retrospective.domain.exception.RetryableUpstreamException;
 import com.fasterxml.jackson.core.JacksonException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.dnd.poc.retrospective.config.AiConfig;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClientException;
-
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.net.http.HttpTimeoutException;
 import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 
 @Component
 @ConditionalOnExpression(AiConfig.LIVE_KEY_CONDITION)
@@ -95,11 +94,7 @@ class SpringAiKptAnalyzer implements KptAnalyzer {
         }
         try {
             return new KptAnalysis(
-                    response.keep(),
-                    response.problem(),
-                    response.tries(),
-                    response.cheerMessage()
-            );
+                    response.keep(), response.problem(), response.tries(), response.cheerMessage());
         } catch (NullPointerException | IllegalArgumentException e) {
             throw new PermanentResponseException(
                     ErrorCode.INVALID_RESPONSE, "AI response invalid: " + e.getMessage(), e);

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/CorrelationIdFilter.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/CorrelationIdFilter.java
@@ -4,14 +4,13 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.UUID;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -21,9 +20,9 @@ class CorrelationIdFilter extends OncePerRequestFilter {
     private static final String MDC_KEY = "correlationId";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain chain) throws ServletException, IOException {
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
         String id = request.getHeader(HEADER);
         if (id == null || id.isBlank()) {
             id = UUID.randomUUID().toString();

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/RetrospectiveController.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/RetrospectiveController.java
@@ -5,7 +5,6 @@ import com.dnd.poc.retrospective.domain.RetrospectiveContext;
 import com.dnd.poc.retrospective.domain.RetrospectiveResult;
 import com.dnd.poc.retrospective.domain.RetrospectiveResult.Failure;
 import com.dnd.poc.retrospective.domain.RetrospectiveResult.Success;
-import com.dnd.poc.retrospective.domain.exception.RetrospectiveGenerationException;
 import com.dnd.poc.retrospective.interfaces.dto.RetrospectiveRequest;
 import com.dnd.poc.retrospective.interfaces.dto.RetrospectiveResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,24 +35,43 @@ public class RetrospectiveController {
 
     @Operation(
             summary = "KPT 회고 분석",
-            description = "취준생의 텍스트를 KPT(Keep/Problem/Try) 프레임워크와 응원 메시지로 구조화해 반환합니다."
-    )
+            description = "취준생의 텍스트를 KPT(Keep/Problem/Try) 프레임워크와 응원 메시지로 구조화해 반환합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "분석 성공",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = RetrospectiveResponse.class))),
-            @ApiResponse(responseCode = "400", description = "입력 검증 실패 (빈 값 / 2000자 초과)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class))),
-            @ApiResponse(responseCode = "422", description = "AI 응답이 빈/잘못된 형식 (EMPTY_RESPONSE, INVALID_RESPONSE)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class))),
-            @ApiResponse(responseCode = "502", description = "업스트림 LLM 호출 실패 (UPSTREAM_UNAVAILABLE)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class))),
-            @ApiResponse(responseCode = "504", description = "업스트림 LLM 타임아웃 (UPSTREAM_TIMEOUT)",
-                    content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            schema = @Schema(implementation = ProblemDetail.class)))
+        @ApiResponse(
+                responseCode = "200",
+                description = "분석 성공",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                schema = @Schema(implementation = RetrospectiveResponse.class))),
+        @ApiResponse(
+                responseCode = "400",
+                description = "입력 검증 실패 (빈 값 / 2000자 초과)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "AI 응답이 빈/잘못된 형식 (EMPTY_RESPONSE, INVALID_RESPONSE)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class))),
+        @ApiResponse(
+                responseCode = "502",
+                description = "업스트림 LLM 호출 실패 (UPSTREAM_UNAVAILABLE)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class))),
+        @ApiResponse(
+                responseCode = "504",
+                description = "업스트림 LLM 타임아웃 (UPSTREAM_TIMEOUT)",
+                content =
+                        @Content(
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                schema = @Schema(implementation = ProblemDetail.class)))
     })
     @PostMapping(value = "/analyze", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> analyze(@Valid @RequestBody RetrospectiveRequest request) {
@@ -62,9 +80,11 @@ public class RetrospectiveController {
         return switch (result) {
             case Success s -> ResponseEntity.ok(RetrospectiveResponse.from(s.analysis()));
             case Failure f -> {
-                ProblemDetail pd = ProblemDetail.forStatusAndDetail(
-                        org.springframework.http.HttpStatusCode.valueOf(f.code().getHttpStatus()),
-                        "AI 회고 생성에 실패했습니다.");
+                ProblemDetail pd =
+                        ProblemDetail.forStatusAndDetail(
+                                org.springframework.http.HttpStatusCode.valueOf(
+                                        f.code().getHttpStatus()),
+                                "AI 회고 생성에 실패했습니다.");
                 pd.setProperty("errorCode", f.code().name());
                 yield ResponseEntity.status(f.code().getHttpStatus()).body(pd);
             }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveRequest.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveRequest.java
@@ -8,14 +8,11 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "회고 분석 요청")
 public record RetrospectiveRequest(
         @Schema(
-                description = "사용자가 작성한 회고 원문 (1~2000자)",
-                example = "오늘 코테에서 시간이 부족해서 마지막 문제를 못 풀었어요. 자료구조 공부가 부족했던 것 같아요.",
-                minLength = 1,
-                maxLength = RetrospectiveContext.MAX_LENGTH,
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        @NotBlank(message = "context must not be blank")
-        @Size(max = RetrospectiveContext.MAX_LENGTH, message = "context too long")
-        String context
-) {
-}
+                        description = "사용자가 작성한 회고 원문 (1~2000자)",
+                        example = "오늘 코테에서 시간이 부족해서 마지막 문제를 못 풀었어요. 자료구조 공부가 부족했던 것 같아요.",
+                        minLength = 1,
+                        maxLength = RetrospectiveContext.MAX_LENGTH,
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                @NotBlank(message = "context must not be blank")
+                @Size(max = RetrospectiveContext.MAX_LENGTH, message = "context too long")
+                String context) {}

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveResponse.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/dto/RetrospectiveResponse.java
@@ -3,29 +3,21 @@ package com.dnd.poc.retrospective.interfaces.dto;
 import com.dnd.poc.retrospective.domain.KptAnalysis;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 @Schema(description = "KPT 분석 결과")
 public record RetrospectiveResponse(
         @Schema(description = "잘하고 있는 점", example = "[\"끝까지 시도한 점\",\"본인 약점을 객관화한 점\"]")
-        List<String> keep,
-
-        @Schema(description = "객관적·개선 가능한 사실", example = "[\"시간 분배 전략 부재\"]")
-        List<String> problem,
-
+                List<String> keep,
+        @Schema(description = "객관적·개선 가능한 사실", example = "[\"시간 분배 전략 부재\"]") List<String> problem,
         @Schema(description = "내일 실행할 수 있는 작은 액션", example = "[\"자료구조 30분 복습\"]")
-        @JsonProperty("try") List<String> tries,
-
+                @JsonProperty("try")
+                List<String> tries,
         @Schema(description = "따뜻한 위로·응원 한마디", example = "오늘도 시도한 것만으로 충분해요.")
-        @JsonProperty("cheer_message") String cheerMessage
-) {
+                @JsonProperty("cheer_message")
+                String cheerMessage) {
     public static RetrospectiveResponse from(KptAnalysis analysis) {
         return new RetrospectiveResponse(
-                analysis.keep(),
-                analysis.problem(),
-                analysis.tries(),
-                analysis.cheerMessage()
-        );
+                analysis.keep(), analysis.problem(), analysis.tries(), analysis.cheerMessage());
     }
 }

--- a/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/exception/GlobalExceptionHandler.java
+++ b/poc/juneseok/src/main/java/com/dnd/poc/retrospective/interfaces/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.dnd.poc.retrospective.interfaces.exception;
 
 import com.dnd.poc.retrospective.domain.RetrospectiveResult.ErrorCode;
 import com.dnd.poc.retrospective.domain.exception.RetrospectiveGenerationException;
+import java.net.URI;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -9,9 +11,6 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.net.URI;
-import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -33,9 +32,10 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ProblemDetail handleValidation(MethodArgumentNotValidException e) {
-        String detail = e.getBindingResult().getFieldErrors().stream()
-                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
-                .collect(Collectors.joining(", "));
+        String detail =
+                e.getBindingResult().getFieldErrors().stream()
+                        .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                        .collect(Collectors.joining(", "));
         ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail);
         pd.setTitle("Validation failed");
         pd.setType(TYPE_VALIDATION);

--- a/src/main/java/com/ddd/webbb/emotion/domain/PostEmotion.java
+++ b/src/main/java/com/ddd/webbb/emotion/domain/PostEmotion.java
@@ -17,9 +17,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 @Entity
-@Table(
-        name = "post_emotion",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
+@Table(name = "post_emotion", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
 public class PostEmotion extends BaseCreatedEntity {
 
     @Id

--- a/src/main/java/com/ddd/webbb/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ddd/webbb/global/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.ddd.webbb.global.common.exception;
 import com.ddd.webbb.global.common.response.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,6 +13,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(AppException.class)
     public ResponseEntity<ApiResponse<Void>> handleAppException(AppException e) {
@@ -56,6 +60,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled exception", e);
         return ResponseEntity.internalServerError()
                 .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
     }

--- a/src/main/java/com/ddd/webbb/global/config/MdcFilter.java
+++ b/src/main/java/com/ddd/webbb/global/config/MdcFilter.java
@@ -1,0 +1,64 @@
+package com.ddd.webbb.global.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class MdcFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(MdcFilter.class);
+    private static final String REQUEST_ID_KEY = "requestId";
+    private static final String REQUEST_ID_HEADER = "X-Request-Id";
+
+    private static final Set<String> EXCLUDED_PREFIXES =
+            Set.of("/swagger-ui", "/v3/api-docs", "/actuator");
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String requestId = request.getHeader(REQUEST_ID_HEADER);
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        }
+
+        MDC.put(REQUEST_ID_KEY, requestId);
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+
+        long start = System.currentTimeMillis();
+        String query = request.getQueryString();
+        log.info(
+                ">>> {} {} {}",
+                request.getMethod(),
+                request.getRequestURI(),
+                query != null ? "?" + query : "");
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("<<< {} {}ms", response.getStatus(), elapsed);
+            MDC.clear();
+        }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return EXCLUDED_PREFIXES.stream().anyMatch(path::startsWith);
+    }
+}

--- a/src/main/java/com/ddd/webbb/global/config/MdcFilter.java
+++ b/src/main/java/com/ddd/webbb/global/config/MdcFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -23,6 +24,10 @@ public class MdcFilter extends OncePerRequestFilter {
     private static final String REQUEST_ID_KEY = "requestId";
     private static final String REQUEST_ID_HEADER = "X-Request-Id";
 
+    private static final Pattern REQUEST_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]{1,64}$");
+    private static final Set<String> SENSITIVE_PARAMS =
+            Set.of("token", "access_token", "refresh_token", "password", "email", "secret", "key");
+
     private static final Set<String> EXCLUDED_PREFIXES =
             Set.of("/swagger-ui", "/v3/api-docs", "/actuator");
 
@@ -32,7 +37,9 @@ public class MdcFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         String requestId = request.getHeader(REQUEST_ID_HEADER);
-        if (requestId == null || requestId.isBlank()) {
+        if (requestId == null
+                || requestId.isBlank()
+                || !REQUEST_ID_PATTERN.matcher(requestId).matches()) {
             requestId = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
         }
 
@@ -40,12 +47,7 @@ public class MdcFilter extends OncePerRequestFilter {
         response.setHeader(REQUEST_ID_HEADER, requestId);
 
         long start = System.currentTimeMillis();
-        String query = request.getQueryString();
-        log.info(
-                ">>> {} {} {}",
-                request.getMethod(),
-                request.getRequestURI(),
-                query != null ? "?" + query : "");
+        log.info(">>> {} {} {}", request.getMethod(), request.getRequestURI(), maskQuery(request));
 
         try {
             filterChain.doFilter(request, response);
@@ -54,6 +56,33 @@ public class MdcFilter extends OncePerRequestFilter {
             log.info("<<< {} {}ms", response.getStatus(), elapsed);
             MDC.clear();
         }
+    }
+
+    private String maskQuery(HttpServletRequest request) {
+        String query = request.getQueryString();
+        if (query == null || query.isBlank()) {
+            return "";
+        }
+
+        StringBuilder masked = new StringBuilder("?");
+        String[] pairs = query.split("&");
+        for (int i = 0; i < pairs.length; i++) {
+            if (i > 0) {
+                masked.append('&');
+            }
+            int eq = pairs[i].indexOf('=');
+            if (eq < 0) {
+                masked.append(pairs[i]);
+                continue;
+            }
+            String key = pairs[i].substring(0, eq).toLowerCase();
+            if (SENSITIVE_PARAMS.contains(key)) {
+                masked.append(pairs[i], 0, eq).append("=***");
+            } else {
+                masked.append(pairs[i]);
+            }
+        }
+        return masked.toString();
     }
 
     @Override

--- a/src/main/java/com/ddd/webbb/global/config/MdcFilter.java
+++ b/src/main/java/com/ddd/webbb/global/config/MdcFilter.java
@@ -47,14 +47,14 @@ public class MdcFilter extends OncePerRequestFilter {
         response.setHeader(REQUEST_ID_HEADER, requestId);
 
         long start = System.currentTimeMillis();
-        log.info(">>> {} {} {}", request.getMethod(), request.getRequestURI(), maskQuery(request));
+        log.debug(">>> {} {} {}", request.getMethod(), request.getRequestURI(), maskQuery(request));
 
         try {
             filterChain.doFilter(request, response);
         } finally {
             long elapsed = System.currentTimeMillis() - start;
-            log.info("<<< {} {}ms", response.getStatus(), elapsed);
-            MDC.clear();
+            log.debug("<<< {} {}ms", response.getStatus(), elapsed);
+            MDC.remove(REQUEST_ID_KEY);
         }
     }
 

--- a/src/main/java/com/ddd/webbb/monster/domain/Monster.java
+++ b/src/main/java/com/ddd/webbb/monster/domain/Monster.java
@@ -17,9 +17,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 @Entity
-@Table(
-        name = "monster",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
+@Table(name = "monster", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id"}))
 public class Monster extends BaseEntity {
 
     @Id

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -25,6 +25,8 @@
 
     <!-- prod -->
     <springProfile name="prod">
+        <property name="LOG_PATH" value="${LOG_PATH:-/var/log/webbb}"/>
+
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
                 <pattern>${LOG_PATTERN}</pattern>
@@ -32,12 +34,12 @@
         </appender>
 
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>logs/webbb.log</file>
+            <file>${LOG_PATH}/webbb.log</file>
             <encoder>
                 <pattern>${LOG_PATTERN}</pattern>
             </encoder>
             <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern>logs/webbb.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <fileNamePattern>${LOG_PATH}/webbb.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
                 <maxFileSize>50MB</maxFileSize>
                 <maxHistory>30</maxHistory>
                 <totalSizeCap>500MB</totalSizeCap>
@@ -46,7 +48,7 @@
 
         <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
             <queueSize>1024</queueSize>
-            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
             <includeCallerData>false</includeCallerData>
             <appender-ref ref="FILE"/>
         </appender>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{requestId:-}] %-5level %logger{36} - %msg%n"/>
+    <property name="LOG_PATTERN_COLOR"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr([%thread]){magenta} %clr([%X{requestId:-}]){cyan} %clr(%-5level) %clr(%logger{36}){blue} %clr(-){faint} %msg%n"/>
+
+    <!-- local -->
+    <springProfile name="local">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOG_PATTERN_COLOR}</pattern>
+            </encoder>
+        </appender>
+
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="org.hibernate.orm.jdbc.bind" level="TRACE"/>
+
+        <root level="DEBUG">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!-- prod -->
+    <springProfile name="prod">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/webbb.log</file>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/webbb.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>500MB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>1024</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <includeCallerData>false</includeCallerData>
+            <appender-ref ref="FILE"/>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+    </springProfile>
+
+    <!-- test -->
+    <springProfile name="test">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <root level="WARN">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## Summary
- Logback 로깅 설정 (logback-spring.xml): local/prod/test 프로파일별 분리
- MDC 필터: 요청마다 requestId 자동 생성, 요청/응답 로깅
- GlobalExceptionHandler: catch-all 핸들러에 log.error 추가

## Logback 선택 근거

### 왜 Logback인가?
| 기준 | Logback | Log4j2 |
|------|---------|--------|
| Spring Boot 기본 | **기본 내장** (별도 의존성 불필요) | starter-logging 제외 + log4j2 추가 필요 |
| 설정 편의성 | **springProfile** 태그로 프로파일별 설정 | Spring Boot lookup 플러그인 별도 필요 |
| 성능 (동기) | 충분 | Logback 대비 미미한 차이 |
| 성능 (비동기 대량) | AsyncAppender로 충분 | **LMAX Disruptor 기반 우위** |
| 생태계 | Spring Boot 공식 문서 기준 | 커뮤니티 설정 예제 상대적으로 적음 |

**현재 단계에서는 Logback이 적합합니다:**
- Spring Boot 기본 내장으로 추가 의존성 없음
- `<springProfile>` 태그로 프로파일별 설정이 간결
- 초기 트래픽 규모에서 성능 차이 무의미
- AsyncAppender로 비동기 파일 I/O 충분히 커버

### Log4j2 전환 기준 (향후)
다음 조건 중 하나라도 해당되면 Log4j2 전환을 검토합니다:
1. **초당 로그 1만 건 이상** — Disruptor 기반 비동기 로깅 필요
2. **GC 압박** — Log4j2의 garbage-free 모드 필요
3. **구조화 로깅 (JSON)** — Log4j2 Layout이 더 유연
4. **런타임 설정 변경** — Log4j2는 재시작 없이 설정 리로드 지원

### 전환 시 작업 범위
- `spring-boot-starter-logging` 제외, `spring-boot-starter-log4j2` 추가
- `logback-spring.xml` → `log4j2-spring.xml` 변환
- MdcFilter는 SLF4J 기반이므로 변경 없음

## 프로파일별 설정

| 프로파일 | 레벨 | 출력 | 특이사항 |
|---------|------|------|---------|
| local | DEBUG | 콘솔 (컬러) | Hibernate SQL/bind 파라미터 출력 |
| prod | INFO | 콘솔 + AsyncAppender → 파일 롤링 | 50MB/파일, 일별, 30일 보관, 총 500MB |
| test | WARN | 콘솔 | 테스트 로그 최소화 |

## MDC 필터
- 요청마다 12자리 hex requestId 자동 생성 (또는 `X-Request-Id` 헤더 전파)
- `>>> METHOD URI` / `<<< STATUS elapsed_ms` 형태로 요청/응답 로깅
- swagger-ui, api-docs, actuator 경로 제외

## Test plan
- [x] `./gradlew spotlessCheck` 통과
- [x] `./gradlew :test` 통과
- [ ] local 서버 기동 후 콘솔에 requestId, 컬러 출력 확인
- [ ] API 호출 시 `X-Request-Id` 응답 헤더 확인

closes #17