### PR TITLE
[Build] Release Please 토큰을 PAT로 변경

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           release-type: simple
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GHCR_TOKEN }}
 
   deploy:
     needs: release-please


### PR DESCRIPTION
## Summary
- Release Please 토큰을 `GITHUB_TOKEN`에서 `GHCR_TOKEN`(PAT)으로 변경
- `GITHUB_TOKEN`으로 생성한 이벤트는 GitHub 보안 정책상 후속 워크플로우를 트리거하지 않아 릴리스 PR 생성이 실패했던 문제 해결

closes #22