### PR TITLE
[BE] 운영 API 요청 로그(access log) 도입

### DIFF
--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -134,6 +134,37 @@ Stage 2 (실행)    eclipse-temurin:21-jre  →  JAR만 복사해서 실행
 | DB 접속 | `${DB_URL}` | RDS JDBC URL 전체를 환경변수로 주입 (SSL 포함) |
 | Redis 접속 | `${REDIS_HOST}`, `${REDIS_PORT}` | 환경변수로 주입 |
 
+### 운영 요청 로그
+
+운영 요청 로그는 애플리케이션 access log 기준으로 `stdout`에서 확인하는 것을 기본으로 한다.
+
+- 일반 요청: `INFO`
+- 서버 오류(`5xx`): `WARN`
+- 지연 요청(`1000ms` 이상): `WARN`
+- 제외 경로: `/swagger-ui`, `/v3/api-docs`, `/actuator`
+
+기록 필드:
+
+- `method`
+- `path`
+- 마스킹된 `query`
+- `status`
+- `durationMs`
+- `requestId`
+- `clientIp`
+
+기록하지 않는 항목:
+
+- 요청 body
+- 응답 body
+- Authorization/Cookie 등 민감 헤더
+
+운영 확인 예시:
+
+```bash
+docker logs webbb-app --tail 200
+```
+
 ---
 
 ## GitHub Secrets 설정

--- a/src/main/java/com/ddd/webbb/global/config/MdcFilter.java
+++ b/src/main/java/com/ddd/webbb/global/config/MdcFilter.java
@@ -5,8 +5,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.LongSupplier;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +25,8 @@ public class MdcFilter extends OncePerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(MdcFilter.class);
     private static final String REQUEST_ID_KEY = "requestId";
     private static final String REQUEST_ID_HEADER = "X-Request-Id";
+    private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
+    private static final long DEFAULT_SLOW_REQUEST_THRESHOLD_MS = 1_000L;
 
     private static final Pattern REQUEST_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]{1,64}$");
     private static final Set<String> SENSITIVE_PARAMS =
@@ -30,6 +34,18 @@ public class MdcFilter extends OncePerRequestFilter {
 
     private static final Set<String> EXCLUDED_PREFIXES =
             Set.of("/swagger-ui", "/v3/api-docs", "/actuator");
+
+    private final LongSupplier currentTimeMillisSupplier;
+    private final long slowRequestThresholdMs;
+
+    public MdcFilter() {
+        this(System::currentTimeMillis, DEFAULT_SLOW_REQUEST_THRESHOLD_MS);
+    }
+
+    MdcFilter(LongSupplier currentTimeMillisSupplier, long slowRequestThresholdMs) {
+        this.currentTimeMillisSupplier = currentTimeMillisSupplier;
+        this.slowRequestThresholdMs = slowRequestThresholdMs;
+    }
 
     @Override
     protected void doFilterInternal(
@@ -46,22 +62,47 @@ public class MdcFilter extends OncePerRequestFilter {
         MDC.put(REQUEST_ID_KEY, requestId);
         response.setHeader(REQUEST_ID_HEADER, requestId);
 
-        long start = System.currentTimeMillis();
-        log.debug(">>> {} {} {}", request.getMethod(), request.getRequestURI(), maskQuery(request));
+        long start = currentTimeMillisSupplier.getAsLong();
+        log.info(
+                "HTTP IN method={} path={} query={} clientIp={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                maskQuery(request),
+                extractClientIp(request));
 
         try {
             filterChain.doFilter(request, response);
         } finally {
-            long elapsed = System.currentTimeMillis() - start;
-            log.debug("<<< {} {}ms", response.getStatus(), elapsed);
+            long elapsed = currentTimeMillisSupplier.getAsLong() - start;
+            logCompletion(request, response, elapsed);
             MDC.remove(REQUEST_ID_KEY);
         }
+    }
+
+    private void logCompletion(
+            HttpServletRequest request, HttpServletResponse response, long elapsed) {
+        if (response.getStatus() >= 500 || elapsed >= slowRequestThresholdMs) {
+            log.warn(
+                    "HTTP OUT method={} path={} status={} durationMs={}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    response.getStatus(),
+                    elapsed);
+            return;
+        }
+
+        log.info(
+                "HTTP OUT method={} path={} status={} durationMs={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                response.getStatus(),
+                elapsed);
     }
 
     private String maskQuery(HttpServletRequest request) {
         String query = request.getQueryString();
         if (query == null || query.isBlank()) {
-            return "";
+            return "-";
         }
 
         StringBuilder masked = new StringBuilder("?");
@@ -75,7 +116,7 @@ public class MdcFilter extends OncePerRequestFilter {
                 masked.append(pairs[i]);
                 continue;
             }
-            String key = pairs[i].substring(0, eq).toLowerCase();
+            String key = pairs[i].substring(0, eq).toLowerCase(Locale.ROOT);
             if (SENSITIVE_PARAMS.contains(key)) {
                 masked.append(pairs[i], 0, eq).append("=***");
             } else {
@@ -83,6 +124,18 @@ public class MdcFilter extends OncePerRequestFilter {
             }
         }
         return masked.toString();
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            int commaIndex = forwardedFor.indexOf(',');
+            if (commaIndex >= 0) {
+                return forwardedFor.substring(0, commaIndex).trim();
+            }
+            return forwardedFor.trim();
+        }
+        return request.getRemoteAddr();
     }
 
     @Override

--- a/src/test/java/com/ddd/webbb/global/config/MdcFilterTest.java
+++ b/src/test/java/com/ddd/webbb/global/config/MdcFilterTest.java
@@ -1,0 +1,144 @@
+package com.ddd.webbb.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.servlet.FilterChain;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class MdcFilterTest {
+
+    private final Logger logger = (Logger) LoggerFactory.getLogger(MdcFilter.class);
+    private final Level originalLevel = logger.getLevel();
+    private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+        logger.setLevel(originalLevel);
+        appender.stop();
+    }
+
+    @Test
+    void 요청_시작과_종료_로그를_info로_남기고_민감_쿼리를_마스킹한다() throws Exception {
+        MdcFilter filter = new MdcFilter(supplierOf(1_000L, 1_050L), 1_000L);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users");
+        request.setQueryString("email=test@example.com&page=1");
+        request.addHeader("X-Request-Id", "trace-1234");
+        request.addHeader("X-Forwarded-For", "203.0.113.10, 10.0.0.1");
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        attachAppender();
+
+        filter.doFilterInternal(request, response, noopChain());
+
+        assertThat(response.getHeader("X-Request-Id")).isEqualTo("trace-1234");
+        assertThat(appender.list).hasSize(2);
+        assertThat(appender.list.get(0).getLevel()).isEqualTo(Level.INFO);
+        assertThat(appender.list.get(0).getFormattedMessage())
+                .isEqualTo(
+                        "HTTP IN method=GET path=/api/users query=?email=***&page=1 clientIp=203.0.113.10");
+        assertThat(appender.list.get(1).getLevel()).isEqualTo(Level.INFO);
+        assertThat(appender.list.get(1).getFormattedMessage())
+                .isEqualTo("HTTP OUT method=GET path=/api/users status=200 durationMs=50");
+        assertThat(appender.list.get(1).getMDCPropertyMap())
+                .containsEntry("requestId", "trace-1234");
+    }
+
+    @Test
+    void 잘못된_request_id는_새로_발급한다() throws Exception {
+        MdcFilter filter = new MdcFilter(supplierOf(1_000L, 1_010L), 1_000L);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users");
+        request.addHeader("X-Request-Id", "invalid request id");
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        attachAppender();
+
+        filter.doFilterInternal(request, response, noopChain());
+
+        String issuedRequestId = response.getHeader("X-Request-Id");
+        assertThat(issuedRequestId).matches("^[a-zA-Z0-9\\-]{1,64}$");
+        assertThat(issuedRequestId).isNotEqualTo("invalid request id");
+        assertThat(appender.list.get(1).getMDCPropertyMap())
+                .containsEntry("requestId", issuedRequestId);
+    }
+
+    @Test
+    void 서버_오류는_warn으로_남긴다() throws Exception {
+        MdcFilter filter = new MdcFilter(supplierOf(1_000L, 1_050L), 1_000L);
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/users");
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        attachAppender();
+
+        filter.doFilterInternal(
+                request, response, (req, res) -> ((MockHttpServletResponse) res).setStatus(500));
+
+        assertThat(appender.list).hasSize(2);
+        assertThat(appender.list.get(1).getLevel()).isEqualTo(Level.WARN);
+        assertThat(appender.list.get(1).getFormattedMessage())
+                .isEqualTo("HTTP OUT method=POST path=/api/users status=500 durationMs=50");
+    }
+
+    @Test
+    void 지연_요청은_warn으로_남긴다() throws Exception {
+        MdcFilter filter = new MdcFilter(supplierOf(1_000L, 2_500L), 1_000L);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users");
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        attachAppender();
+
+        filter.doFilterInternal(request, response, noopChain());
+
+        assertThat(appender.list).hasSize(2);
+        assertThat(appender.list.get(1).getLevel()).isEqualTo(Level.WARN);
+        assertThat(appender.list.get(1).getFormattedMessage())
+                .isEqualTo("HTTP OUT method=GET path=/api/users status=200 durationMs=1500");
+    }
+
+    @Test
+    void 제외_경로는_필터에서_제외한다() {
+        MdcFilter filter = new MdcFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/actuator/health");
+
+        assertThat(filter.shouldNotFilter(request)).isTrue();
+    }
+
+    private void attachAppender() {
+        logger.setLevel(Level.INFO);
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    private FilterChain noopChain() {
+        return (request, response) -> {};
+    }
+
+    private LongSupplier supplierOf(long... values) {
+        Queue<Long> queue = new ArrayDeque<>();
+        for (long value : values) {
+            queue.add(value);
+        }
+        return () -> {
+            Long value = queue.poll();
+            if (value == null) {
+                throw new IllegalStateException("No more timestamps available");
+            }
+            return value;
+        };
+    }
+}


### PR DESCRIPTION
## PR 제목(내용 요약)
[BE] 운영 API 요청 로그(access log) 도입

## 📌 변경 내용 & 이유
- 운영 환경에서 `MdcFilter` 요청 로그가 `DEBUG` 레벨이라 사실상 보이지 않던 문제를 개선했습니다.
- 요청 시작/종료 로그를 access log 형태로 정리하고, 운영에서도 `INFO` 이상으로 확인할 수 있도록 변경했습니다.
- `5xx` 응답과 1000ms 이상 지연 요청은 `WARN`으로 승격해 장애 대응 시 눈에 띄도록 했습니다.
- 민감 쿼리 파라미터는 기존처럼 마스킹하고, `X-Forwarded-For` 기준 client IP 추적을 추가했습니다.
- 운영에서는 `stdout` 기준으로 로그를 확인하도록 `docs/cicd.md` 문서도 보강했습니다.

## 📸 스크린샷 (선택)
UI 변경 사항 없음

## 🧪 테스트 방법 (선택)
- `./gradlew test`
- `./gradlew spotlessCheck`
- `MdcFilterTest`에서 아래 시나리오 검증
  - 정상 요청 `INFO` 로그
  - `5xx` 응답 `WARN` 로그
  - 1000ms 이상 지연 요청 `WARN` 로그
  - 민감 쿼리 파라미터 마스킹
  - `X-Request-Id` 유지 및 재발급
  - `/swagger-ui`, `/v3/api-docs`, `/actuator` 제외

## 📢 논의하고 싶은 내용
- 현재는 애플리케이션 access log를 `stdout` 중심으로 운영하도록 두었습니다.
- 추후 Nginx/ALB access log를 함께 운영하게 되면 역할 분담을 어떻게 가져갈지 추가 논의가 필요합니다.

## 🧩 관련 이슈
Closes #40