### PR TITLE
fix(ai): disable claude provider by default

### DIFF
--- a/src/main/java/com/ddd/webbb/ai/infrastructure/config/AiConfig.java
+++ b/src/main/java/com/ddd/webbb/ai/infrastructure/config/AiConfig.java
@@ -13,6 +13,7 @@ import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.Order;
@@ -26,6 +27,10 @@ public class AiConfig {
     @Bean
     @Order(1)
     @ConditionalOnBean(AnthropicChatModel.class)
+    @ConditionalOnProperty(
+            prefix = "app.ai.providers",
+            name = "claude-enabled",
+            havingValue = "true")
     public ClaudeAiProvider claudeAiProvider(AnthropicChatModel model) {
         return new ClaudeAiProvider(ChatClient.builder(model).build());
     }
@@ -33,6 +38,11 @@ public class AiConfig {
     @Bean
     @Order(2)
     @ConditionalOnBean(OpenAiChatModel.class)
+    @ConditionalOnProperty(
+            prefix = "app.ai.providers",
+            name = "openai-enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     public OpenAiAiProvider openAiAiProvider(OpenAiChatModel model) {
         return new OpenAiAiProvider(ChatClient.builder(model).build());
     }

--- a/src/main/java/com/ddd/webbb/ai/infrastructure/config/AiProperties.java
+++ b/src/main/java/com/ddd/webbb/ai/infrastructure/config/AiProperties.java
@@ -2,6 +2,13 @@ package com.ddd.webbb.ai.infrastructure.config;
 
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 
 @ConfigurationProperties(prefix = "app.ai")
-public record AiProperties(String promptVersion, Duration timeout) {}
+public record AiProperties(
+        String promptVersion, Duration timeout, @DefaultValue Providers providers) {
+
+    public record Providers(
+            @DefaultValue("false") boolean claudeEnabled,
+            @DefaultValue("true") boolean openaiEnabled) {}
+}

--- a/src/main/java/com/ddd/webbb/ai/interfaces/AiTestController.java
+++ b/src/main/java/com/ddd/webbb/ai/interfaces/AiTestController.java
@@ -101,13 +101,13 @@ public class AiTestController {
                                                                 """
                             {
                               "success": true,
-                              "data": {
+                                "data": {
                                 "emotionType": "ANXIETY",
                                 "hp": 30,
                                 "confidence": 0.91,
                                 "reason": "불안과 긴장 표현이 반복적으로 드러남",
                                 "crisisDetected": false,
-                                "usedProvider": "CLAUDE"
+                                "usedProvider": "OPENAI"
                               },
                               "error": null
                             }
@@ -129,9 +129,10 @@ public class AiTestController {
             댓글 내용을 AI로 분석해 100자 이내 요약과 톤(CALM/NEUTRAL/URGENT)을 반환합니다.
 
             동작 방식:
-            1. Claude → OpenAI → Static 순서로 AI 프로바이더를 시도합니다.
-            2. 파싱 실패 시 기본값("요약 실패", NEUTRAL)을 반환합니다.
-            3. `usedProvider` 필드에서 실제로 응답한 프로바이더를 확인할 수 있습니다.
+            1. 기본적으로 OpenAI → Static 순서로 AI 프로바이더를 시도합니다.
+            2. Claude는 설정으로 명시적으로 활성화한 경우에만 등록됩니다.
+            3. 파싱 실패 시 기본값("요약 실패", NEUTRAL)을 반환합니다.
+            4. `usedProvider` 필드에서 실제로 응답한 프로바이더를 확인할 수 있습니다.
             """,
             requestBody =
                     @RequestBody(
@@ -163,7 +164,7 @@ public class AiTestController {
                               "data": {
                                 "summary": "힘내라는 따뜻한 위로와 응원의 메시지",
                                 "tone": "CALM",
-                                "usedProvider": "CLAUDE"
+                                "usedProvider": "OPENAI"
                               },
                               "error": null
                             }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,9 @@ app:
   ai:
     prompt-version: ${PROMPT_VERSION:v1}
     timeout: ${AI_TIMEOUT:20s}
+    providers:
+      claude-enabled: false
+      openai-enabled: true
 
 resilience4j:
   retry:

--- a/src/test/java/com/ddd/webbb/ai/infrastructure/config/AiConfigTest.java
+++ b/src/test/java/com/ddd/webbb/ai/infrastructure/config/AiConfigTest.java
@@ -1,0 +1,61 @@
+package com.ddd.webbb.ai.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddd.webbb.ai.infrastructure.gateway.ClaudeAiProvider;
+import com.ddd.webbb.ai.infrastructure.gateway.OpenAiAiProvider;
+import com.ddd.webbb.ai.infrastructure.gateway.StaticAiProvider;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class AiConfigTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(AiConfig.class))
+                    .withPropertyValues("app.ai.prompt-version=v1", "app.ai.timeout=5s");
+
+    @Test
+    void 기본값에서는_Claude는_비활성화되고_OpenAI와_Static만_등록된다() {
+        contextRunner
+                .withBean(AnthropicChatModel.class, () -> Mockito.mock(AnthropicChatModel.class))
+                .withBean(OpenAiChatModel.class, () -> Mockito.mock(OpenAiChatModel.class))
+                .run(
+                        context -> {
+                            assertThat(context).doesNotHaveBean(ClaudeAiProvider.class);
+                            assertThat(context).hasSingleBean(OpenAiAiProvider.class);
+                            assertThat(context).hasSingleBean(StaticAiProvider.class);
+                        });
+    }
+
+    @Test
+    void Claude를_명시적으로_활성화하면_Claude도_등록된다() {
+        contextRunner
+                .withPropertyValues("app.ai.providers.claude-enabled=true")
+                .withBean(AnthropicChatModel.class, () -> Mockito.mock(AnthropicChatModel.class))
+                .withBean(OpenAiChatModel.class, () -> Mockito.mock(OpenAiChatModel.class))
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(ClaudeAiProvider.class);
+                            assertThat(context).hasSingleBean(OpenAiAiProvider.class);
+                            assertThat(context).hasSingleBean(StaticAiProvider.class);
+                        });
+    }
+
+    @Test
+    void OpenAI를_비활성화하면_Static만_남는다() {
+        contextRunner
+                .withPropertyValues("app.ai.providers.openai-enabled=false")
+                .withBean(OpenAiChatModel.class, () -> Mockito.mock(OpenAiChatModel.class))
+                .run(
+                        context -> {
+                            assertThat(context).doesNotHaveBean(ClaudeAiProvider.class);
+                            assertThat(context).doesNotHaveBean(OpenAiAiProvider.class);
+                            assertThat(context).hasSingleBean(StaticAiProvider.class);
+                        });
+    }
+}

--- a/src/test/java/com/ddd/webbb/ai/interfaces/AiTestControllerTest.java
+++ b/src/test/java/com/ddd/webbb/ai/interfaces/AiTestControllerTest.java
@@ -33,7 +33,7 @@ class AiTestControllerTest {
     @Test
     void 감정_분석_요청을_처리한다() throws Exception {
         AiAnalysisResponse mockResponse =
-                new AiAnalysisResponse("ANXIETY", 30, 0.9, "불안 표현이 강함", false, "CLAUDE");
+                new AiAnalysisResponse("ANXIETY", 30, 0.9, "불안 표현이 강함", false, "OPENAI");
         given(aiAnalysisService.analyze(any(PostContent.class))).willReturn(mockResponse);
 
         mockMvc.perform(
@@ -48,7 +48,7 @@ class AiTestControllerTest {
                 .andExpect(jsonPath("$.data.emotionType").value("ANXIETY"))
                 .andExpect(jsonPath("$.data.hp").value(30))
                 .andExpect(jsonPath("$.data.crisisDetected").value(false))
-                .andExpect(jsonPath("$.data.usedProvider").value("CLAUDE"));
+                .andExpect(jsonPath("$.data.usedProvider").value("OPENAI"));
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,6 +2,9 @@ app:
   ai:
     prompt-version: v1
     timeout: 5s
+    providers:
+      claude-enabled: false
+      openai-enabled: true
 
 spring:
   profiles:


### PR DESCRIPTION
## PR 제목(내용 요약)
Claude provider 기본 비활성화 및 AI provider 토글 설정 추가

## 📌 변경 내용 & 이유
- Claude를 기본 비활성화하고 OpenAI를 기본 provider로 사용하도록 `app.ai.providers` 설정을 추가했습니다.
- `AiConfig`에서 provider 빈 등록을 `@ConditionalOnProperty`로 분기해 Claude는 명시적으로 켠 경우에만 등록되도록 변경했습니다.
- 테스트/Swagger 예시를 새 기본 정책에 맞춰 정리하고, provider 등록 조건을 검증하는 설정 테스트를 추가했습니다.

## 📸 스크린샷 (선택)
UI 변경 없음

## 🧪 테스트 방법 (선택)
- `./gradlew test -x :poc:allkite:test --rerun-tasks --tests com.ddd.webbb.ai.infrastructure.config.AiConfigTest --tests com.ddd.webbb.ai.interfaces.AiTestControllerTest --tests com.ddd.webbb.ai.interfaces.AiTestControllerProdProfileTest --tests com.ddd.webbb.ai.infrastructure.gateway.DefaultAiGatewayTest --tests com.ddd.webbb.ai.application.AiAnalysisServiceTest --tests com.ddd.webbb.comment.application.CommentSummaryServiceTest`
- `./gradlew spotlessCheck -x :poc:allkite:test`

## 📢 논의하고 싶은 내용
- 현재는 Anthropic 의존성은 유지하고 provider만 기본 비활성화했습니다. Claude를 완전히 제거할지 여부는 별도 판단이 필요합니다.

## 🧩 관련 이슈
Close #44