### PR TITLE
chore(cicd): 수동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,98 @@
+name: Manual Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_tests:
+        description: '테스트 건너뛰기 (긴급 배포 시 사용)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image name (lowercase)
+        run: echo "IMAGE_NAME=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests
+        if: ${{ !inputs.skip_tests }}
+        run: ./gradlew test
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Copy docker-compose to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: docker-compose.prod.yml
+          target: ~/app
+
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
+
+            export GITHUB_REPOSITORY=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
+            export DB_URL="${{ secrets.DB_URL }}"
+            export DB_USERNAME="${{ secrets.DB_USERNAME }}"
+            export DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
+            export OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
+
+            cd ~/app
+            docker compose -f docker-compose.prod.yml pull app
+            docker compose -f docker-compose.prod.yml up -d
+
+            echo "Waiting for application to start..."
+            for i in $(seq 1 30); do
+              if curl -sf http://localhost:8080/actuator/health > /dev/null 2>&1; then
+                echo "Application is healthy!"
+                exit 0
+              fi
+              sleep 5
+            done
+
+            echo "ERROR: Health check failed after 150 seconds."
+            docker compose -f docker-compose.prod.yml logs app --tail 50
+            exit 1

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -40,25 +40,50 @@ Release PR 머지 ──→ GitHub Release + 태그 + CHANGELOG 자동 업데이
 
 ---
 
-### 2. CD — `.github/workflows/cd.yml`
+### 2-A. 자동 배포 — `.github/workflows/release-please.yml` (deploy job)
 
 | 항목 | 값 |
 |---|---|
-| 트리거 | `main` 브랜치에 push (= PR 머지) |
-| 목적 | 서버 자동 배포 |
+| 트리거 | Release PR 머지 시 (`release_created == true`) |
+| 목적 | 릴리스 생성에 연동된 자동 배포 |
 
 **실행 단계:**
 
 1. **이미지 이름 소문자 변환** — GHCR은 대문자를 허용하지 않으므로 `github.repository`를 소문자로 변환
 2. **테스트 재실행** — 머지 후 최종 검증
-3. **Docker 이미지 빌드 & GHCR push** — 두 개 태그로 push
+3. **Docker 이미지 빌드 & GHCR push** — 세 개 태그로 push
    - `latest` — 항상 최신 빌드를 가리킴
    - `<commit-sha>` — 특정 커밋으로 롤백할 때 사용
+   - `<release-tag>` — 릴리스 버전 (예: `v1.3.0`)
 4. **SCP로 compose 파일 전송** — EC2의 `~/app`에 최신 `docker-compose.prod.yml` 배치
 5. **SSH 접속 후 배포** — `docker compose pull` → `up -d`로 컨테이너 교체
 6. **Health check** — 최대 150초(5초 × 30회) 대기하며 `/actuator/health` 확인
    - 성공 시 `exit 0` → 워크플로우 성공
    - 실패 시 앱 로그 출력 후 `exit 1` → **워크플로우 실패 처리**
+
+> `chore:`, `docs:` 등 non-releasable 커밋만 있으면 Release PR이 생성되지 않아 배포가 실행되지 않을 수 있다.  
+> 이 경우 아래 수동 배포를 사용한다.
+
+---
+
+### 2-B. 수동 배포 — `.github/workflows/deploy.yml`
+
+| 항목 | 값 |
+|---|---|
+| 트리거 | GitHub Actions UI에서 직접 실행 (`workflow_dispatch`) |
+| 목적 | Release PR 없이 즉시 배포 |
+
+**실행 단계:**
+
+1~6은 자동 배포와 동일. 단, 릴리스 태그는 붙이지 않음 (`:latest`, `:<sha>` 두 개만 push).
+
+**입력값:**
+
+| 이름 | 설명 | 기본값 |
+|---|---|---|
+| `skip_tests` | 테스트 건너뛰기 | `false` |
+
+**사용법:** Actions 탭 → "Manual Deploy" → "Run workflow" 버튼
 
 ---
 
@@ -229,8 +254,8 @@ mkdir -p ~/app
 | `docker-compose.prod.yml` | 운영 배포용 Compose |
 | `src/main/resources/application-prod.yml` | 운영 Spring 프로필 |
 | `.github/workflows/ci.yml` | PR 시 CI 워크플로우 |
-| `.github/workflows/cd.yml` | main push 시 CD 워크플로우 |
-| `.github/workflows/release-please.yml` | main push 시 릴리즈 자동화 |
+| `.github/workflows/deploy.yml` | 수동 배포 워크플로우 |
+| `.github/workflows/release-please.yml` | main push 시 릴리즈 자동화 + 자동 배포 |
 
 ---
 


### PR DESCRIPTION
## PR 제목(내용 요약)
수동 배포 워크플로우 추가 (`workflow_dispatch`)

## 📌 변경 내용 & 이유

기존 CD는 Release PR 머지 시에만 실행되어, `chore:`/`docs:` 커밋만 있거나 긴급 재배포가 필요한 경우에 배포 수단이 없었습니다.

**추가**
- `.github/workflows/deploy.yml`: GitHub Actions UI에서 직접 트리거하는 수동 배포 워크플로우
  - `skip_tests` 옵션으로 긴급 배포 시 테스트 건너뛰기 가능
  - 이미지 태그 `:latest`, `:<git-sha>` 두 개로 GHCR 푸시
  - EC2 배포 및 헬스체크는 기존 자동 배포와 동일한 방식

**수정**
- `docs/cicd.md`: CD 섹션을 자동 배포(2-A)와 수동 배포(2-B)로 분리, 존재하지 않는 `cd.yml` 참조 제거

## 🧪 테스트 방법 (선택)

Actions 탭 → "Manual Deploy" → "Run workflow" 버튼 → 브랜치 선택 → 실행

## 📢 논의하고 싶은 내용

없음

## 🧩 관련 이슈

closes #47