### PR TITLE
fix(cicd): 운영 배포 안정성 보강

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: webbb-ec2-deploy
+      cancel-in-progress: false
+      queue: max
 
     steps:
       - name: Checkout
@@ -95,4 +99,5 @@ jobs:
 
             echo "ERROR: Health check failed after 150 seconds."
             docker compose -f docker-compose.prod.yml logs app --tail 50
+            docker compose -f docker-compose.prod.yml stop app
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,6 @@ jobs:
     concurrency:
       group: webbb-ec2-deploy
       cancel-in-progress: false
-      queue: max
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,6 @@ jobs:
     concurrency:
       group: webbb-ec2-deploy
       cancel-in-progress: false
-      queue: max
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,10 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: webbb-ec2-deploy
+      cancel-in-progress: false
+      queue: max
 
     steps:
       - name: Checkout
@@ -109,4 +113,5 @@ jobs:
 
             echo "ERROR: Health check failed after 150 seconds."
             docker compose -f docker-compose.prod.yml logs app --tail 50
+            docker compose -f docker-compose.prod.yml stop app
             exit 1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,12 +4,16 @@ services:
     container_name: webbb-app
     ports:
       - "8080:8080"
+    mem_limit: ${APP_MEM_LIMIT:-768m}
+    mem_reservation: ${APP_MEM_RESERVATION:-512m}
+    cpus: ${APP_CPU_LIMIT:-1.0}
     environment:
       SPRING_PROFILES_ACTIVE: prod
       DB_URL: ${DB_URL}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      JAVA_TOOL_OPTIONS: -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=25.0
       REDIS_HOST: redis
       REDIS_PORT: 6379
     depends_on:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## PR 제목(내용 요약)
fix(cicd): 운영 배포 안정성 보강

## 📌 변경 내용 & 이유
최근 CD 실행 시 서버가 순간적으로 불안정해질 수 있는 지점을 점검하면서, 운영 배포 경로만 최소 범위로 보강했습니다.

- 수동 배포와 release 배포 job에 `concurrency`를 추가해 같은 EC2로 배포가 겹치지 않도록 했습니다.
- health check가 끝까지 통과하지 못하면 앱 로그만 남기고 끝내지 않고, `docker compose stop app`으로 재시작 루프를 끊도록 바꿨습니다.
- 운영 `docker-compose.prod.yml`에 CPU/메모리 제한과 `JAVA_TOOL_OPTIONS`를 추가해 작은 인스턴스에서 JVM이 호스트 메모리를 과하게 잡아먹지 않도록 조정했습니다.
- `application-prod.yml`의 `ddl-auto`를 `update`에서 `validate`로 바꿔 배포 시점의 스키마 변경 부담을 없앴습니다.

## 📸 스크린샷 (선택)
UI 변경 없음

## 🧪 테스트 방법 (선택)
- `./gradlew test`
- `docker compose -f docker-compose.prod.yml config`
- workflow YAML 파싱 확인
- 운영 서버 사전 점검
  - `docker inspect webbb-app` 기준 `RestartCount=0`, `OOMKilled=false`
  - `curl http://localhost:8080/actuator/health` → `{"status":"UP"}`

## 📢 논의하고 싶은 내용
현재 운영 EC2는 메모리가 1GiB도 안 되는 편이라, 이번 제한값을 넣어도 배포 직후 startup 피크가 아주 넉넉한 상태는 아닙니다.
가능하면 다음 단계에서 swap 추가나 인스턴스 상향도 같이 검토하면 더 안정적으로 가져갈 수 있을 것 같습니다.

## 🧩 관련 이슈
없음
