### PR TITLE
feat(cicd): 특정 릴리즈 버전 수동 배포 지원

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,18 @@ name: Manual Deploy
 on:
   workflow_dispatch:
     inputs:
+      deploy_mode:
+        description: '배포 방식 선택'
+        required: true
+        default: latest
+        type: choice
+        options:
+          - latest
+          - release_tag
+      release_tag:
+        description: '배포할 릴리즈 태그 (예: v1.3.0)'
+        required: false
+        type: string
       skip_tests:
         description: '테스트 건너뛰기 (긴급 배포 시 사용)'
         required: false
@@ -24,23 +36,47 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate inputs and determine image tag
+        run: |
+          deploy_mode="${{ inputs.deploy_mode }}"
+          release_tag="${{ inputs.release_tag }}"
+
+          if [ "$deploy_mode" = "release_tag" ]; then
+            if [ -z "$release_tag" ]; then
+              echo "release_tag is required when deploy_mode=release_tag"
+              exit 1
+            fi
+
+            if ! printf '%s' "$release_tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "release_tag must match v<major>.<minor>.<patch>"
+              exit 1
+            fi
+
+            echo "IMAGE_TAG=$release_tag" >> "$GITHUB_ENV"
+          else
+            echo "IMAGE_TAG=latest" >> "$GITHUB_ENV"
+          fi
+
       - name: Set image name (lowercase)
         run: echo "IMAGE_NAME=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Set up JDK 21
+        if: ${{ inputs.deploy_mode == 'latest' }}
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
+        if: ${{ inputs.deploy_mode == 'latest' }}
         uses: gradle/actions/setup-gradle@v4
 
       - name: Grant execute permission for gradlew
+        if: ${{ inputs.deploy_mode == 'latest' }}
         run: chmod +x gradlew
 
       - name: Run tests
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ inputs.deploy_mode == 'latest' && !inputs.skip_tests }}
         run: ./gradlew test
 
       - name: Log in to GHCR
@@ -51,6 +87,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
+        if: ${{ inputs.deploy_mode == 'latest' }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -83,6 +120,7 @@ jobs:
             export DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
             export OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
             export JWT_SECRET="${{ secrets.JWT_SECRET }}"
+            export IMAGE_TAG="${{ env.IMAGE_TAG }}"
 
             cd ~/app
             docker compose -f docker-compose.prod.yml pull app

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -96,6 +96,7 @@ jobs:
             export DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
             export OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
             export JWT_SECRET="${{ secrets.JWT_SECRET }}"
+            export IMAGE_TAG=latest
 
             cd ~/app
             docker compose -f docker-compose.prod.yml pull app

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/${GITHUB_REPOSITORY}:latest
+    image: ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG:-latest}
     container_name: webbb-app
     ports:
       - "8080:8080"

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -71,19 +71,50 @@ Release PR 머지 ──→ GitHub Release + 태그 + CHANGELOG 자동 업데이
 | 항목 | 값 |
 |---|---|
 | 트리거 | GitHub Actions UI에서 직접 실행 (`workflow_dispatch`) |
-| 목적 | Release PR 없이 즉시 배포 |
+| 목적 | Release PR 없이 즉시 배포하거나, 특정 릴리즈 버전을 재배포 |
 
-**실행 단계:**
+**동작 모드:**
 
-1~6은 자동 배포와 동일. 단, 릴리스 태그는 붙이지 않음 (`:latest`, `:<sha>` 두 개만 push).
+- `latest`
+  - 현재 브랜치 기준으로 새 이미지를 빌드해 배포
+  - 태그는 `:latest`, `:<sha>` 두 개를 push
+- `release_tag`
+  - 기존 GHCR 릴리즈 태그 이미지를 재배포
+  - 새 이미지는 빌드하지 않음
 
 **입력값:**
 
 | 이름 | 설명 | 기본값 |
 |---|---|---|
+| `deploy_mode` | `latest` 또는 `release_tag` | `latest` |
+| `release_tag` | `deploy_mode=release_tag` 일 때 배포할 릴리즈 태그 (예: `v1.3.0`) | `""` |
 | `skip_tests` | 테스트 건너뛰기 | `false` |
 
+**실행 단계:**
+
+### `deploy_mode=latest`
+
+1. 입력값 검증 후 `IMAGE_TAG=latest` 설정
+2. 테스트 실행 (`skip_tests=false` 일 때만)
+3. Docker 이미지 빌드 & GHCR push
+4. 운영 서버에 `latest` 이미지 배포
+5. `/actuator/health` 헬스체크
+
+### `deploy_mode=release_tag`
+
+1. 입력값 검증
+   - `release_tag` 필수
+   - 형식: `v<major>.<minor>.<patch>` 예: `v1.3.0`
+2. `IMAGE_TAG=<release_tag>` 설정
+3. 새 이미지 빌드 없이 EC2에서 해당 태그 이미지 pull
+4. `/actuator/health` 헬스체크
+
 **사용법:** Actions 탭 → "Manual Deploy" → "Run workflow" 버튼
+
+**주의사항:**
+
+- GitHub Actions의 `choice` 입력은 정적 옵션만 지원하므로, `release_tag` 는 문자열 직접 입력을 기본으로 사용
+- 특정 버전 재배포는 이미지 롤백만 보장하며, DB 스키마 하위호환은 별도 보장하지 않음
 
 ---
 
@@ -145,6 +176,7 @@ Stage 2 (실행)    eclipse-temurin:21-jre  →  JAR만 복사해서 실행
 | redis | redis:7.0 | 캐시/세션 저장소 | 없음 (내부 전용) |
 
 - DB는 AWS RDS(MySQL)를 사용하며, `DB_URL` 환경변수로 JDBC URL 전체를 주입
+- app 이미지는 `${IMAGE_TAG}` 값을 기준으로 선택되며, 값이 없으면 `latest` 를 기본 사용
 - app은 redis가 healthy 상태일 때만 시작 (`depends_on` + `healthcheck`)
 - redis는 호스트 포트를 노출하지 않음 (Docker 내부 네트워크로만 통신)
 - 모든 민감 정보는 환경변수로 주입 (하드코딩 금지)


### PR DESCRIPTION
## PR 제목(내용 요약)

feat(cicd): 특정 릴리즈 버전 수동 배포 지원

## 📌 변경 내용 & 이유

### 수동 배포 워크플로우 확장
- `Manual Deploy` 에 `deploy_mode`, `release_tag` 입력값을 추가해 최신 배포와 특정 릴리즈 태그 배포를 분리
- `deploy_mode=release_tag` 일 때는 `release_tag` 입력을 검증하고, 새 이미지를 빌드하지 않고 기존 GHCR 태그 이미지를 그대로 배포하도록 구성
- `deploy_mode=latest` 일 때만 JDK/Gradle 설정, 테스트, Docker build & push 가 실행되도록 분기 처리

### 운영 배포 태그 명시화
- 운영 compose 이미지 태그를 `latest` 고정에서 `${IMAGE_TAG:-latest}` 기반으로 변경
- 수동 배포에서는 입력값에 따라 `IMAGE_TAG=latest` 또는 `IMAGE_TAG=<release_tag>` 를 주입
- 자동 릴리즈 배포도 `IMAGE_TAG=latest` 를 명시적으로 export 하도록 맞춰 기존 동작과의 호환성을 유지

### 문서화
- CI/CD 가이드에 `latest` / `release_tag` 배포 모드, 입력 규칙, 운영 주의사항을 반영
- 특정 릴리즈 재배포는 이미지 롤백만 보장하며 DB 스키마 하위호환은 별도 보장하지 않는 점을 명시

## 🧪 테스트 방법

- `git diff --check`
- GitHub Actions 수동 배포 기준 확인
  - `deploy_mode=latest` 인 경우에만 테스트와 이미지 빌드가 수행되는지 확인
  - `deploy_mode=release_tag` 인 경우 `release_tag` 검증 후 기존 태그 이미지를 pull 하는지 확인

## 📢 논의하고 싶은 내용

- GitHub Actions `choice` 입력은 정적 옵션만 지원하므로, 현재는 `release_tag` 를 문자열 직접 입력으로 유지함
- 운영 편의상 최근 릴리즈 몇 개를 정적 드롭다운으로 보조 노출할지는 추후 별도 판단 가능

## 🧩 관련 이슈

- Closes #60