### PR TITLE
fix: dev 배포 환경변수 전달 누락 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 
 # QueryDSL generated
 src/main/generated/
+
+.codex/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,8 @@ services:
       DB_URL: ${DB_URL}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      JWT_SECRET: ${JWT_SECRET}
       REDIS_HOST: redis
       REDIS_PORT: 6379
     depends_on:


### PR DESCRIPTION
## PR 제목(내용 요약)
fix: dev 배포 환경변수 전달 누락 수정

## 📌 변경 내용 & 이유
- dev 배포용 compose에 `OPENAI_API_KEY`, `JWT_SECRET` 환경변수 전달을 추가
- GitHub Actions `deploy-dev`에서 export한 값이 실제 `webbb-dev-app` 컨테이너 내부로 전달되도록 수정
- `JWT_SECRET` 누락으로 인한 Spring Boot 부팅 실패와 health check 실패를 해결하기 위한 변경
- `.codex/` 로컬 작업 디렉터리를 `.gitignore`에 추가해 불필요한 추적을 방지

## 📸 스크린샷 (선택)
> UI 변경 없음

## 🧪 테스트 방법 (선택)
- `./gradlew test`
- 아래 명령으로 dev compose 렌더링 확인
```bash
JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456 OPENAI_API_KEY=test-key DB_URL=jdbc:mysql://db:3306/webbb DB_USERNAME=test DB_PASSWORD=test REDIS_HOST=redis REDIS_PORT=6379 GITHUB_REPOSITORY=ddd-community/ddd-13-webbb_be docker compose -f docker-compose.dev.yml config
```
- 렌더링 결과의 `webbb-dev-app.environment`에 `JWT_SECRET`, `OPENAI_API_KEY`가 포함되는지 확인

## 📢 논의하고 싶은 내용
- 없음

## 🧩 관련 이슈
- Close #65
