### PR TITLE
fix(deploy): secret 특수문자로 인한 배포 실패 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,27 +107,32 @@ jobs:
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DB_URL_PROD: ${{ secrets.DB_URL_PROD }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+          NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
+          NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
+          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          envs: GHCR_TOKEN,GHCR_USERNAME,GITHUB_REPOSITORY,DB_URL_PROD,DB_USERNAME,DB_PASSWORD,OPENAI_API_KEY,JWT_SECRET,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,NAVER_CLIENT_ID,NAVER_CLIENT_SECRET,FRONTEND_URL,IMAGE_TAG
           script: |
-            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
 
-            export GITHUB_REPOSITORY=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
-            export DB_URL_PROD='${{ secrets.DB_URL_PROD }}'
-            export DB_USERNAME='${{ secrets.DB_USERNAME }}'
-            export DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
-            export OPENAI_API_KEY='${{ secrets.OPENAI_API_KEY }}'
-            export JWT_SECRET='${{ secrets.JWT_SECRET }}'
-            export GOOGLE_CLIENT_ID='${{ secrets.GOOGLE_CLIENT_ID }}'
-            export GOOGLE_CLIENT_SECRET='${{ secrets.GOOGLE_CLIENT_SECRET }}'
-            export KAKAO_CLIENT_ID='${{ secrets.KAKAO_CLIENT_ID }}'
-            export KAKAO_CLIENT_SECRET='${{ secrets.KAKAO_CLIENT_SECRET }}'
-            export NAVER_CLIENT_ID='${{ secrets.NAVER_CLIENT_ID }}'
-            export NAVER_CLIENT_SECRET='${{ secrets.NAVER_CLIENT_SECRET }}'
-            export FRONTEND_URL='${{ secrets.FRONTEND_URL }}'
-            export IMAGE_TAG='${{ env.IMAGE_TAG }}'
+            export GITHUB_REPOSITORY=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
 
             cd ~/app
             docker compose -f docker-compose.prod.yml pull app


### PR DESCRIPTION
## 변경 내용 & 이유

- 배포 시 `KAKAO_CLIENT_SECRET`, `OPENAI_API_KEY` 환경변수가 누락되는 문제 수정
- 원인: `appleboy/ssh-action`의 script 블록에서 `export VAR='${{ secrets.X }}'` 방식으로 직접 치환할 경우, secret 값에 셸 특수문자(`'`, `$` 등)가 포함되면 export가 실패하여 빈 값이 됨
- 해결: `ssh-action`의 `envs` 파라미터를 사용하여 셸 치환 없이 안전하게 환경변수를 전달하도록 변경

## 테스트 방법

- 이 PR 머지 후 Manual Deploy 워크플로우 실행하여 배포 성공 확인
- `KAKAO_CLIENT_SECRET`, `OPENAI_API_KEY` interpolation 에러가 더 이상 발생하지 않는지 확인

## 관련 이슈

- 배포 시 `error while interpolating services.app.environment.KAKAO_CLIENT_SECRET` 에러 발생