### PR TITLE
feat(post): 게시글 목록/상세 조회 및 수정 API 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ DB명: `webbb`
 
 ### 2. 애플리케이션 실행
 
+기본 프로필은 `local`입니다. 처음 실행할 때는 로컬 설정 파일을 템플릿에서 복사해 만듭니다.
+
+```bash
+cp src/main/resources/application-local.yml.example src/main/resources/application-local.yml
+```
+
+필요하면 `src/main/resources/application-local.yml`에서 로컬 DB, Redis, JWT 값을 수정한 뒤 실행합니다.
+
 ```bash
 ./gradlew bootRun
 ```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,7 @@ services:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: dev
+      TZ: Asia/Seoul
       DB_URL: ${DB_URL}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,7 +21,8 @@ services:
       NAVER_CLIENT_ID: ${NAVER_CLIENT_ID:?NAVER_CLIENT_ID is required}
       NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET:?NAVER_CLIENT_SECRET is required}
       FRONTEND_URL: ${FRONTEND_URL:?FRONTEND_URL is required}
-      JAVA_TOOL_OPTIONS: -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=25.0
+      TZ: Asia/Seoul
+      JAVA_TOOL_OPTIONS: -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=25.0 -Duser.timezone=Asia/Seoul
       REDIS_HOST: redis
       REDIS_PORT: 6379
     depends_on:

--- a/src/main/java/com/ddd/webbb/comment/application/CommentService.java
+++ b/src/main/java/com/ddd/webbb/comment/application/CommentService.java
@@ -1,0 +1,22 @@
+package com.ddd.webbb.comment.application;
+
+import com.ddd.webbb.comment.domain.Comment;
+import com.ddd.webbb.comment.domain.CommentRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+
+    public CommentService(CommentRepository commentRepository) {
+        this.commentRepository = commentRepository;
+    }
+
+    public List<Comment> findCommentsByPost(Long postId) {
+        return commentRepository.findByPost_IdAndIsDeletedFalseOrderByCreatedAtAsc(postId);
+    }
+}

--- a/src/main/java/com/ddd/webbb/comment/domain/CommentRepository.java
+++ b/src/main/java/com/ddd/webbb/comment/domain/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.ddd.webbb.comment.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByPost_IdAndIsDeletedFalseOrderByCreatedAtAsc(Long postId);
+}

--- a/src/main/java/com/ddd/webbb/emotion/application/PostEmotionService.java
+++ b/src/main/java/com/ddd/webbb/emotion/application/PostEmotionService.java
@@ -3,11 +3,16 @@ package com.ddd.webbb.emotion.application;
 import com.ddd.webbb.emotion.domain.EmotionType;
 import com.ddd.webbb.emotion.domain.PostEmotion;
 import com.ddd.webbb.emotion.domain.PostEmotionRepository;
+import com.ddd.webbb.global.common.exception.AppException;
+import com.ddd.webbb.global.common.exception.ErrorCode;
 import com.ddd.webbb.post.domain.Post;
 import com.ddd.webbb.user.domain.User;
+import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class PostEmotionService {
 
     private final PostEmotionRepository postEmotionRepository;
@@ -16,7 +21,24 @@ public class PostEmotionService {
         this.postEmotionRepository = postEmotionRepository;
     }
 
+    @Transactional
     public PostEmotion addPostEmotion(Post post, EmotionType emotionType, User user) {
         return postEmotionRepository.save(PostEmotion.create(post, emotionType, user));
+    }
+
+    public PostEmotion findByPost(Long postId) {
+        return postEmotionRepository
+                .findByPost_Id(postId)
+                .orElseThrow(() -> new AppException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    public List<PostEmotion> findByPostIds(List<Long> postIds) {
+        return postEmotionRepository.findByPost_IdIn(postIds);
+    }
+
+    @Transactional
+    public void modifyPostEmotion(Long postId, EmotionType emotionType) {
+        PostEmotion postEmotion = findByPost(postId);
+        postEmotion.updateEmotionType(emotionType);
     }
 }

--- a/src/main/java/com/ddd/webbb/emotion/domain/PostEmotion.java
+++ b/src/main/java/com/ddd/webbb/emotion/domain/PostEmotion.java
@@ -61,4 +61,8 @@ public class PostEmotion extends BaseCreatedEntity {
     public User getUser() {
         return user;
     }
+
+    public void updateEmotionType(EmotionType emotionType) {
+        this.emotionType = emotionType;
+    }
 }

--- a/src/main/java/com/ddd/webbb/emotion/domain/PostEmotionRepository.java
+++ b/src/main/java/com/ddd/webbb/emotion/domain/PostEmotionRepository.java
@@ -1,5 +1,11 @@
 package com.ddd.webbb.emotion.domain;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostEmotionRepository extends JpaRepository<PostEmotion, Long> {}
+public interface PostEmotionRepository extends JpaRepository<PostEmotion, Long> {
+    Optional<PostEmotion> findByPost_Id(Long postId);
+
+    List<PostEmotion> findByPost_IdIn(List<Long> postIds);
+}

--- a/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
@@ -149,9 +149,9 @@ public class SwaggerConfig {
         put(statuses, ApiImplementationStatus.STUB, "GET", "/api/users/me");
         put(statuses, ApiImplementationStatus.STUB, "PATCH", "/api/users/me/profile");
 
-        put(statuses, ApiImplementationStatus.STUB, "GET", "/api/posts");
-        put(statuses, ApiImplementationStatus.STUB, "GET", "/api/posts/{postId}");
-        put(statuses, ApiImplementationStatus.STUB, "PATCH", "/api/posts/{postId}");
+        put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/posts");
+        put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/posts/{postId}");
+        put(statuses, ApiImplementationStatus.LIVE, "PATCH", "/api/posts/{postId}");
         put(statuses, ApiImplementationStatus.LIVE, "DELETE", "/api/posts/{postId}");
 
         put(statuses, ApiImplementationStatus.STUB, "POST", "/api/posts/{postId}/comments");

--- a/src/main/java/com/ddd/webbb/monster/application/MonsterService.java
+++ b/src/main/java/com/ddd/webbb/monster/application/MonsterService.java
@@ -1,12 +1,17 @@
 package com.ddd.webbb.monster.application;
 
 import com.ddd.webbb.emotion.domain.EmotionType;
+import com.ddd.webbb.global.common.exception.AppException;
+import com.ddd.webbb.global.common.exception.ErrorCode;
 import com.ddd.webbb.monster.domain.Monster;
 import com.ddd.webbb.monster.domain.MonsterRepository;
 import com.ddd.webbb.post.domain.Post;
+import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class MonsterService {
 
     private static final int LOW_HP = 10;
@@ -19,8 +24,26 @@ public class MonsterService {
         this.monsterRepository = monsterRepository;
     }
 
+    @Transactional
     public Monster addMonster(Post post, EmotionType emotionType, int hp) {
         return monsterRepository.save(Monster.create(post, emotionType, normalizeHp(hp)));
+    }
+
+    public Monster findByPost(Long postId) {
+        return monsterRepository
+                .findByPost_Id(postId)
+                .orElseThrow(() -> new AppException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    public List<Monster> findByPostIds(List<Long> postIds) {
+        return monsterRepository.findByPost_IdIn(postIds);
+    }
+
+    @Transactional
+    public Monster resetMonster(Long postId, EmotionType emotionType, int hp) {
+        Monster monster = findByPost(postId);
+        monster.reset(emotionType, normalizeHp(hp));
+        return monster;
     }
 
     private int normalizeHp(int hp) {

--- a/src/main/java/com/ddd/webbb/monster/domain/Monster.java
+++ b/src/main/java/com/ddd/webbb/monster/domain/Monster.java
@@ -61,6 +61,13 @@ public class Monster extends BaseEntity {
         }
     }
 
+    public void reset(EmotionType emotionType, int newMaxHp) {
+        this.emotionType = emotionType;
+        this.maxHp = newMaxHp;
+        this.hp = newMaxHp;
+        this.status = MonsterStatus.ALIVE;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/ddd/webbb/monster/domain/MonsterRepository.java
+++ b/src/main/java/com/ddd/webbb/monster/domain/MonsterRepository.java
@@ -1,5 +1,11 @@
 package com.ddd.webbb.monster.domain;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MonsterRepository extends JpaRepository<Monster, Long> {}
+public interface MonsterRepository extends JpaRepository<Monster, Long> {
+    Optional<Monster> findByPost_Id(Long postId);
+
+    List<Monster> findByPost_IdIn(List<Long> postIds);
+}

--- a/src/main/java/com/ddd/webbb/post/application/PostService.java
+++ b/src/main/java/com/ddd/webbb/post/application/PostService.java
@@ -5,19 +5,31 @@ import com.ddd.webbb.ai.application.AiAnalysisService;
 import com.ddd.webbb.ai.domain.PostContent;
 import com.ddd.webbb.category.domain.BoardCategory;
 import com.ddd.webbb.category.domain.BoardCategoryRepository;
+import com.ddd.webbb.comment.application.CommentService;
+import com.ddd.webbb.comment.domain.Comment;
 import com.ddd.webbb.emotion.application.PostEmotionService;
 import com.ddd.webbb.emotion.domain.EmotionType;
+import com.ddd.webbb.emotion.domain.PostEmotion;
 import com.ddd.webbb.global.common.exception.AppException;
 import com.ddd.webbb.global.common.exception.ErrorCode;
 import com.ddd.webbb.monster.application.MonsterService;
 import com.ddd.webbb.monster.domain.Monster;
 import com.ddd.webbb.post.domain.Post;
 import com.ddd.webbb.post.domain.PostRepository;
+import com.ddd.webbb.post.infrastructure.PostRepositoryImpl;
 import com.ddd.webbb.post.interfaces.dto.PostCreateRequest;
 import com.ddd.webbb.post.interfaces.dto.PostCreateResponse;
+import com.ddd.webbb.post.interfaces.dto.PostDetailResponse;
+import com.ddd.webbb.post.interfaces.dto.PostListResponse;
+import com.ddd.webbb.post.interfaces.dto.PostListResponse.MonsterInfo;
+import com.ddd.webbb.post.interfaces.dto.PostListResponse.PostSummary;
+import com.ddd.webbb.post.interfaces.dto.PostResponse;
 import com.ddd.webbb.user.application.UserService;
 import com.ddd.webbb.user.domain.User;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,27 +38,34 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private static final String DEFAULT_CATEGORY_NAME = "멘탈케어";
+    private static final int CONTENT_PREVIEW_LENGTH = 50;
 
     private final PostRepository postRepository;
+    private final PostRepositoryImpl postRepositoryImpl;
     private final BoardCategoryRepository boardCategoryRepository;
     private final UserService userService;
     private final AiAnalysisService aiAnalysisService;
     private final MonsterService monsterService;
     private final PostEmotionService postEmotionService;
+    private final CommentService commentService;
 
     public PostService(
             PostRepository postRepository,
+            PostRepositoryImpl postRepositoryImpl,
             BoardCategoryRepository boardCategoryRepository,
             UserService userService,
             AiAnalysisService aiAnalysisService,
             MonsterService monsterService,
-            PostEmotionService postEmotionService) {
+            PostEmotionService postEmotionService,
+            CommentService commentService) {
         this.postRepository = postRepository;
+        this.postRepositoryImpl = postRepositoryImpl;
         this.boardCategoryRepository = boardCategoryRepository;
         this.userService = userService;
         this.aiAnalysisService = aiAnalysisService;
         this.monsterService = monsterService;
         this.postEmotionService = postEmotionService;
+        this.commentService = commentService;
     }
 
     public PostCreateResponse addPost(UUID userPublicId, PostCreateRequest request) {
@@ -68,6 +87,103 @@ public class PostService {
         return PostCreateResponse.of(post, user, emotionType, monster);
     }
 
+    @Transactional(readOnly = true)
+    public PostListResponse getPosts(Long cursor, int size) {
+        List<Post> fetched = postRepositoryImpl.findByCursor(cursor, size);
+        boolean hasNext = fetched.size() > size;
+        List<Post> posts = hasNext ? fetched.subList(0, size) : fetched;
+
+        List<Long> postIds = posts.stream().map(Post::getId).toList();
+        Map<Long, PostEmotion> emotionMap =
+                postEmotionService.findByPostIds(postIds).stream()
+                        .collect(Collectors.toMap(e -> e.getPost().getId(), e -> e));
+        Map<Long, Monster> monsterMap =
+                monsterService.findByPostIds(postIds).stream()
+                        .collect(Collectors.toMap(m -> m.getPost().getId(), m -> m));
+
+        List<PostSummary> summaries =
+                posts.stream()
+                        .map(
+                                post ->
+                                        toPostSummary(
+                                                post,
+                                                emotionMap.get(post.getId()),
+                                                monsterMap.get(post.getId())))
+                        .toList();
+
+        Long nextCursor = hasNext ? posts.get(posts.size() - 1).getId() : null;
+        return new PostListResponse(summaries, nextCursor);
+    }
+
+    public PostDetailResponse getPostDetail(Long postId) {
+        Post post =
+                postRepository
+                        .findByIdAndIsDeletedFalse(postId)
+                        .orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND));
+        post.incrementViewCount();
+
+        PostEmotion postEmotion = postEmotionService.findByPost(postId);
+        Monster monster = monsterService.findByPost(postId);
+        List<Comment> comments = commentService.findCommentsByPost(postId);
+
+        EmotionType emotionType = postEmotion.getEmotionType();
+        return new PostDetailResponse(
+                post.getId(),
+                new PostDetailResponse.AuthorInfo(
+                        post.getUser().getPublicId().toString(),
+                        post.getUser().getNickname(),
+                        post.getUser().getJobType(),
+                        post.getUser().getCareerLevel()),
+                post.getContent(),
+                post.getCommentTone().name(),
+                new PostDetailResponse.EmotionInfo(
+                        emotionType.name(), emotionType.getDisplayName()),
+                new PostDetailResponse.MonsterInfo(
+                        emotionType.monsterType(),
+                        monster.getHp(),
+                        monster.getMaxHp(),
+                        monster.getStatus().name()),
+                post.getLikeCount(),
+                post.getCommentCount(),
+                comments.stream()
+                        .map(
+                                c ->
+                                        new PostDetailResponse.CommentInfo(
+                                                c.getId(),
+                                                c.getUser().getNickname(),
+                                                c.getContent(),
+                                                c.getCreatedAt()))
+                        .toList(),
+                post.getCreatedAt());
+    }
+
+    public PostResponse modifyPost(UUID userPublicId, Long postId, PostCreateRequest request) {
+        User user = userService.getUserEntity(userPublicId);
+        Post post =
+                postRepository
+                        .findByIdAndIsDeletedFalse(postId)
+                        .orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND));
+
+        if (!post.getUser().getPublicId().equals(user.getPublicId())) {
+            throw new AppException(ErrorCode.FORBIDDEN);
+        }
+
+        boolean contentChanged = !post.getContent().equals(request.content());
+        post.update(request.content(), request.commentTone());
+
+        if (contentChanged) {
+            AiAnalysisResponse analysis =
+                    aiAnalysisService.analyze(new PostContent(post.getId(), post.getContent()));
+            EmotionType emotionType = EmotionType.valueOf(analysis.emotionType());
+            postEmotionService.modifyPostEmotion(postId, emotionType);
+            monsterService.resetMonster(postId, emotionType, analysis.hp());
+        }
+
+        PostEmotion postEmotion = postEmotionService.findByPost(postId);
+        Monster monster = monsterService.findByPost(postId);
+        return PostResponse.of(post, user, postEmotion, monster);
+    }
+
     public void deletePost(UUID userPublicId, Long postId) {
         User user = userService.getUserEntity(userPublicId);
         Post post =
@@ -80,6 +196,34 @@ public class PostService {
         }
 
         post.delete();
+    }
+
+    private PostSummary toPostSummary(Post post, PostEmotion postEmotion, Monster monster) {
+        EmotionType emotionType = postEmotion != null ? postEmotion.getEmotionType() : null;
+        String emotionTypeName = emotionType != null ? emotionType.name() : null;
+        MonsterInfo monsterInfo =
+                monster != null
+                        ? new MonsterInfo(
+                                emotionType != null ? emotionType.monsterType() : null,
+                                monster.getHp(),
+                                monster.getMaxHp(),
+                                monster.getStatus().name())
+                        : null;
+        String preview =
+                post.getContent().length() <= CONTENT_PREVIEW_LENGTH
+                        ? post.getContent()
+                        : post.getContent().substring(0, CONTENT_PREVIEW_LENGTH) + "...";
+        return new PostSummary(
+                post.getId(),
+                post.getUser().getNickname(),
+                post.getUser().getJobType(),
+                post.getUser().getCareerLevel(),
+                preview,
+                emotionTypeName,
+                monsterInfo,
+                post.getLikeCount(),
+                post.getCommentCount(),
+                post.getCreatedAt());
     }
 
     private BoardCategory resolveDefaultCategory() {

--- a/src/main/java/com/ddd/webbb/post/domain/Post.java
+++ b/src/main/java/com/ddd/webbb/post/domain/Post.java
@@ -94,6 +94,20 @@ public class Post extends BaseEntity {
         this.isDeleted = true;
     }
 
+    public void update(String content, CommentTone commentTone) {
+        String normalized = content == null ? "" : content.trim();
+        this.content = content;
+        this.title =
+                normalized.isEmpty()
+                        ? "고민글"
+                        : normalized.substring(0, Math.min(normalized.length(), 30));
+        this.commentTone = commentTone;
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/ddd/webbb/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/com/ddd/webbb/post/infrastructure/PostRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.ddd.webbb.post.infrastructure;
+
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.QPost;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PostRepositoryImpl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PostRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    public List<Post> findByCursor(Long cursor, int size) {
+        QPost post = QPost.post;
+        return queryFactory
+                .selectFrom(post)
+                .where(post.isDeleted.isFalse(), cursor != null ? post.id.lt(cursor) : null)
+                .orderBy(post.id.desc())
+                .limit(size + 1L)
+                .fetch();
+    }
+}

--- a/src/main/java/com/ddd/webbb/post/interfaces/PostController.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/PostController.java
@@ -15,8 +15,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -40,16 +38,6 @@ public class PostController {
     public PostController(PostService postService) {
         this.postService = postService;
     }
-
-    private static final PostResponse.AuthorInfo STUB_AUTHOR =
-            new PostResponse.AuthorInfo(
-                    "01939b10-7b0f-7c8f-9a2b-111111111111", "ogu", "DEVELOPMENT", "YEAR_3");
-
-    private static final PostResponse.EmotionInfo STUB_EMOTION =
-            new PostResponse.EmotionInfo("ANXIETY", "불안", "면접 불합격으로 인한 자신감 저하");
-
-    private static final PostResponse.MonsterInfo STUB_MONSTER =
-            new PostResponse.MonsterInfo("ANXIETY_MONSTER", 80, 100, "ALIVE");
 
     @Operation(
             summary = "게시글 작성 (글 작성)",
@@ -208,22 +196,7 @@ public class PostController {
     public ApiResponse<PostListResponse> getPosts(
             @Parameter(description = "커서 (마지막 postId)") @RequestParam(required = false) Long cursor,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
-        // TODO: 실제 서비스 연동
-        PostListResponse.MonsterInfo monsterInfo =
-                new PostListResponse.MonsterInfo("ANXIETY_MONSTER", 80, 100, "ALIVE");
-        PostListResponse.PostSummary summary =
-                new PostListResponse.PostSummary(
-                        1L,
-                        "ogu",
-                        "DEVELOPMENT",
-                        "YEAR_3",
-                        "면접에서 계속 떨어져서 점점 자신감이...",
-                        "ANXIETY",
-                        monsterInfo,
-                        3,
-                        5,
-                        LocalDateTime.now());
-        return ApiResponse.ok("게시글 목록을 조회했습니다.", new PostListResponse(List.of(summary), null));
+        return ApiResponse.ok("게시글 목록을 조회했습니다.", postService.getPosts(cursor, size));
     }
 
     @Operation(summary = "게시글 상세 조회")
@@ -260,29 +233,7 @@ public class PostController {
     })
     @GetMapping("/{postId}")
     public ApiResponse<PostDetailResponse> getPost(@PathVariable Long postId) {
-        // TODO: 실제 서비스 연동
-        PostDetailResponse.AuthorInfo author =
-                new PostDetailResponse.AuthorInfo(
-                        "01939b10-7b0f-7c8f-9a2b-111111111111", "ogu", "DEVELOPMENT", "YEAR_3");
-        PostDetailResponse.EmotionInfo emotion =
-                new PostDetailResponse.EmotionInfo("ANXIETY", "불안");
-        PostDetailResponse.MonsterInfo monster =
-                new PostDetailResponse.MonsterInfo("ANXIETY_MONSTER", 80, 100, "ALIVE");
-        PostDetailResponse.CommentInfo comment =
-                new PostDetailResponse.CommentInfo(1L, "anonymous", "힘내세요!", LocalDateTime.now());
-        PostDetailResponse response =
-                new PostDetailResponse(
-                        postId,
-                        author,
-                        "면접에서 계속 떨어져서 점점 자신감이 사라져요.",
-                        "COMFORT_ME",
-                        emotion,
-                        monster,
-                        3,
-                        1,
-                        List.of(comment),
-                        LocalDateTime.now());
-        return ApiResponse.ok("게시글을 조회했습니다.", response);
+        return ApiResponse.ok("게시글을 조회했습니다.", postService.getPostDetail(postId));
     }
 
     @Operation(summary = "게시글 수정")
@@ -316,20 +267,11 @@ public class PostController {
     })
     @PatchMapping("/{postId}")
     public ApiResponse<PostResponse> updatePost(
-            @PathVariable Long postId, @RequestBody @Valid PostCreateRequest request) {
-        // TODO: 실제 서비스 연동
-        PostResponse response =
-                new PostResponse(
-                        postId,
-                        STUB_AUTHOR,
-                        request.content(),
-                        request.commentTone().name(),
-                        STUB_EMOTION,
-                        STUB_MONSTER,
-                        3,
-                        5,
-                        LocalDateTime.now());
-        return ApiResponse.ok("게시글이 수정되었습니다.", response);
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long postId,
+            @RequestBody @Valid PostCreateRequest request) {
+        return ApiResponse.ok(
+                "게시글이 수정되었습니다.", postService.modifyPost(principal.publicId(), postId, request));
     }
 
     @Operation(summary = "게시글 삭제")

--- a/src/main/java/com/ddd/webbb/post/interfaces/dto/PostResponse.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/dto/PostResponse.java
@@ -1,5 +1,10 @@
 package com.ddd.webbb.post.interfaces.dto;
 
+import com.ddd.webbb.emotion.domain.EmotionType;
+import com.ddd.webbb.emotion.domain.PostEmotion;
+import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.user.domain.User;
 import java.time.LocalDateTime;
 
 public record PostResponse(
@@ -12,6 +17,29 @@ public record PostResponse(
         int likeCount,
         int commentCount,
         LocalDateTime createdAt) {
+
+    public static PostResponse of(Post post, User user, PostEmotion postEmotion, Monster monster) {
+        EmotionType emotionType = postEmotion.getEmotionType();
+        return new PostResponse(
+                post.getId(),
+                new AuthorInfo(
+                        user.getPublicId().toString(),
+                        user.getNickname(),
+                        user.getJobType(),
+                        user.getCareerLevel()),
+                post.getContent(),
+                post.getCommentTone().name(),
+                new EmotionInfo(
+                        emotionType.name(), emotionType.getDisplayName(), emotionType.getSummary()),
+                new MonsterInfo(
+                        emotionType.monsterType(),
+                        monster.getHp(),
+                        monster.getMaxHp(),
+                        monster.getStatus().name()),
+                post.getLikeCount(),
+                post.getCommentCount(),
+                post.getCreatedAt());
+    }
 
     public record AuthorInfo(String id, String nickname, String jobRole, String careerYear) {}
 

--- a/src/main/resources/application-local.yml.example
+++ b/src/main/resources/application-local.yml.example
@@ -1,0 +1,26 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiAudioTranscriptionAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiImageAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiModerationAutoConfiguration
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/webbb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: webbb
+    password: webbb
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    show-sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret: dev-only-secret-key-must-be-at-least-256-bits-long-for-hmac-sha

--- a/src/test/java/com/ddd/webbb/post/application/PostServiceTest.java
+++ b/src/test/java/com/ddd/webbb/post/application/PostServiceTest.java
@@ -12,6 +12,7 @@ import com.ddd.webbb.ai.application.AiAnalysisResponse;
 import com.ddd.webbb.ai.application.AiAnalysisService;
 import com.ddd.webbb.category.domain.BoardCategory;
 import com.ddd.webbb.category.domain.BoardCategoryRepository;
+import com.ddd.webbb.comment.application.CommentService;
 import com.ddd.webbb.emotion.application.PostEmotionService;
 import com.ddd.webbb.emotion.domain.EmotionType;
 import com.ddd.webbb.global.common.exception.AppException;
@@ -21,6 +22,7 @@ import com.ddd.webbb.monster.domain.Monster;
 import com.ddd.webbb.post.domain.CommentTone;
 import com.ddd.webbb.post.domain.Post;
 import com.ddd.webbb.post.domain.PostRepository;
+import com.ddd.webbb.post.infrastructure.PostRepositoryImpl;
 import com.ddd.webbb.post.interfaces.dto.PostCreateRequest;
 import com.ddd.webbb.post.interfaces.dto.PostCreateResponse;
 import com.ddd.webbb.user.application.UserService;
@@ -34,29 +36,35 @@ import org.springframework.test.util.ReflectionTestUtils;
 class PostServiceTest {
 
     private PostRepository postRepository;
+    private PostRepositoryImpl postRepositoryImpl;
     private BoardCategoryRepository boardCategoryRepository;
     private UserService userService;
     private AiAnalysisService aiAnalysisService;
     private MonsterService monsterService;
     private PostEmotionService postEmotionService;
+    private CommentService commentService;
     private PostService postService;
 
     @BeforeEach
     void setUp() {
         postRepository = mock(PostRepository.class);
+        postRepositoryImpl = mock(PostRepositoryImpl.class);
         boardCategoryRepository = mock(BoardCategoryRepository.class);
         userService = mock(UserService.class);
         aiAnalysisService = mock(AiAnalysisService.class);
         monsterService = mock(MonsterService.class);
         postEmotionService = mock(PostEmotionService.class);
+        commentService = mock(CommentService.class);
         postService =
                 new PostService(
                         postRepository,
+                        postRepositoryImpl,
                         boardCategoryRepository,
                         userService,
                         aiAnalysisService,
                         monsterService,
-                        postEmotionService);
+                        postEmotionService,
+                        commentService);
     }
 
     @Test


### PR DESCRIPTION
## PR 제목(내용 요약)

feat(post): 게시글 목록/상세 조회 및 수정 API 구현

## 📌 변경 내용 & 이유

**PostController / LikeController에 STUB 상태로 남아 있던 3개 API를 실제 서비스와 연동하여 구현했습니다.**

### GET /api/posts — 게시글 목록 조회
- `PostRepositoryImpl`: QueryDSL 커서 기반 페이지네이션 (`size+1` 조회로 `hasNext` 판단)
- `PostEmotion`, `Monster`는 `postIds IN (...)` 쿼리로 한 번에 조회 후 Map으로 조합 → N+1 방지
- `contentPreview`: 본문 앞 50자 미리보기

### GET /api/posts/{postId} — 게시글 상세 조회
- `viewCount` 증가 처리
- `CommentRepository` / `CommentService` 신규 추가 — 삭제되지 않은 댓글 목록 포함
- 감정(EmotionType), 몬스터(Monster) 정보 함께 반환

### PATCH /api/posts/{postId} — 게시글 수정
- 본인 게시글 여부 권한 검증
- `content` 변경 시에만 AI 재분석 수행 → `PostEmotion` 업데이트 + `Monster` HP 리셋
- `commentTone`만 변경 시 AI 호출 없음
- 기존 컨트롤러에 누락되어 있던 `@AuthenticationPrincipal` 추가

### 공통 기반 확장
- `Post.update()`, `Post.incrementViewCount()` 도메인 메서드 추가
- `Monster.reset(emotionType, newMaxHp)` 추가 — 수정 시 HP 초기화
- `PostEmotion.updateEmotionType()` 추가
- `MonsterRepository`, `PostEmotionRepository`에 단건/목록 조회 메서드 추가
- `PostEmotionService`, `MonsterService` 기능 확장 (단건/목록 조회, 수정)
- `SwaggerConfig`: 구현 완료 3개 API 라벨 `STUB → LIVE` 업데이트

### 기타
- `application-local.yml.example` 로컬 설정 템플릿 추가 및 README 실행 가이드 보완
- dev/prod 컨테이너 타임존 `Asia/Seoul` 설정 추가

## 🧪 테스트 방법

```bash
# 빌드 및 전체 테스트
./gradlew build

# 게시글 작성 후 아래 API 순서로 확인
# 1. POST /api/posts → postId 획득
# 2. GET  /api/posts → 목록에 해당 게시글 포함 여부, nextCursor 확인
# 3. GET  /api/posts/{postId} → 상세 조회, viewCount 증가 확인
# 4. PATCH /api/posts/{postId} → content 변경 시 emotion/monster 변경 여부 확인
#                              → commentTone만 변경 시 emotion/monster 유지 확인
```

`PostServiceTest` — 기존 테스트 그대로 통과 확인 (생성자 의존성만 업데이트)

## 📢 논의하고 싶은 내용

- `PATCH /api/posts/{postId}` 수정 시 `content`가 바뀌면 Monster HP를 새 `maxHp`로 **완전 리셋**하도록 구현했습니다. 기존 좋아요로 감소된 HP가 초기화되는데, 다른 방식(예: 현재 HP 비율 유지)이 더 적합할지 논의가 필요합니다.

## 🧩 관련 이슈

Close #72