### PR TITLE
[BE] feat: EC2 CPU/로그 → Discord 알림 모니터링 인프라 추가

### DIFF
--- a/docs/superpowers/specs/2026-06-05-ec2-cpu-log-discord-alerts-design.md
+++ b/docs/superpowers/specs/2026-06-05-ec2-cpu-log-discord-alerts-design.md
@@ -1,0 +1,120 @@
+# EC2 CPU/로그 → Discord 알림 설계서
+
+- 작성일: 2026-06-05
+- 대상: WEBBB BE (Spring Boot 3.4.5 / Java 21), AWS 계정 `729859598191`, EC2 배포
+- 검증: codex(비용/사실관계) + omc-architect(구조/운영) + omc-critic(적대적) 3중 리뷰 반영
+- 제약: **AWS Free Tier 내** · IaC = CloudFormation · **앱 Java 코드 무수정**
+
+## 1. 목표
+
+1. **CPU 피크 알림**: EC2 CPU가 지속적으로 높으면 알림.
+2. **로그 반복 알림**: 특정 예외/키워드가 일정 시간 내 N회 이상이면 알림.
+3. 두 알림 모두 **Discord 채널 `1512246623642718308`** 에 **이대리 봇**으로 게시.
+
+## 2. 아키텍처
+
+```
+[EC2 CPUUtilization(기본 5분)] ───────────────► [CW Alarm: CPU≥80%, 3주기 중 2]
+                                                         │
+[앱 STDOUT 로그] ─(런타임별 수집: §6)─► [CW Logs /webbb/app (Retention 14d)]
+        + CloudWatch Agent multi_line_start_pattern 으로 스택트레이스 1이벤트 병합
+                                                         │
+                              [Metric Filter: 예외/키워드 → AppErrorCount (defaultValue 0)]
+                                                         │
+                              [CW Alarm: Sum≥N / 5분]
+                                                         │
+   CPU·로그 Alarm ──(ALARM/OK)──► [SNS: webbb-alerts] ──► [Lambda(py3.12) 변환기]
+                                                              │ timeout 8s, 429 backoff
+                                                              │ 봇토큰=SSM SecureString
+                                                              ▼
+                                  POST /channels/1512246623642718308/messages (Bot)
+                                                              │ 실패(async 2회 재시도 후)
+                                                              ▼  [DLQ(SQS)]
+   [Self-monitoring]
+   · EventBridge(1일 1회) → Lambda → Discord "✅ 정상 동작 중" (데드맨 스위치)
+   · Lambda Errors / DLQ depth Alarm ──► [SNS: webbb-ops] ──► 이메일 (Discord와 분리된 경로)
+```
+
+**핵심 사실**: SNS는 Discord로 직접 전송 불가(SNS는 email/SMS/HTTP(S)/SQS/Lambda만 지원, Discord 봇 REST 포맷과 불일치) → **Lambda 변환기 필수**. (codex 확인)
+
+## 3. 설계 결정 및 근거
+
+| 결정 | 내용 | 근거 |
+|---|---|---|
+| Discord 전송 | **이대리 봇 토큰** (Webhook 아님) | 사용자 결정. 리뷰어 3인은 Webhook 권고했으나, 봇 유지 시 §5 하드닝으로 위험 상쇄 |
+| 봇 토큰 보관 | SSM Parameter Store **SecureString** | Secrets Manager는 유료. SSM standard + aws/ssm 키는 Free Tier |
+| CPU 알람 정책 | EvaluationPeriods 3 / Datapoints 2 | 순간 출렁임(flapping) 억제. 로그 알람과 정책 분리 (architect) |
+| 로그 알람 정책 | Sum≥N / Period300 / Eval1 / Datapoints1 | "5분 내 N회" 의미와 일치 (codex 권장값) |
+| 멀티라인 | Agent `multi_line_start_pattern` | Java 스택트레이스를 1이벤트로 → 예외 1건=1카운트 (B3) |
+| self-monitoring | Heartbeat + Lambda/DLQ 알람(이메일 별도경로) | 알림 시스템 자체 장애 탐지 (B4). 같은 경로 재사용 시 무한루프 → 분리 |
+| Lambda 코드 | Python 3.12 인라인(urllib, 무의존) | 패키징/S3 불필요. 4KB 이내 유지 |
+| 로그 본문 | embed엔 메타데이터만(알람명/상태/사유/시각) | 민감정보 Discord 유출 방지 (critic S2) |
+
+## 4. 컴포넌트
+
+### 4.1 CPU 알람
+- `AWS/EC2 CPUUtilization`, Dimension `InstanceId`, 기본(5분) 모니터링 (상세 1분은 유료 → 제외)
+- 평균 ≥ 80%, Period 300, EvaluationPeriods 3, DatapointsToAlarm 2, TreatMissingData notBreaching
+- AlarmActions + OKActions → `webbb-alerts`
+- 한계: 5분 해상도라 순간(2~3분) 스파이크는 희석될 수 있음 — "피크"=지속 고부하 기준.
+
+### 4.2 로그 수집 (§6 런타임별)
+- LogGroup `/webbb/app`, **RetentionInDays 14** (5GB/월 비용 방어, 이 스택이 소유)
+- Agent 사용 시 `multi_line_start_pattern = "^\d{4}-\d{2}-\d{2}"`
+
+### 4.3 Metric Filter + 로그 알람
+- 패턴(기본): `?ERROR ?Exception` (파라미터로 특정 예외 클래스명 지정 가능). **실측 로그로 콘솔 Test Pattern 검증 필수**
+- 메트릭 `WEBBB/App AppErrorCount`, value 1, **defaultValue 0**
+- 알람: Sum ≥ N(기본 10) / 300 / Eval1 / Datapoints1, TreatMissingData notBreaching
+- 한계: N=에러 "로그 라인 수"≈사건 수. 운영 초기 실측 보정.
+
+### 4.4 Lambda 변환기 (Python 3.12)
+- 트리거 SNS(`webbb-alerts`), timeout 8s, urllib만
+- SNS→CloudWatch Alarm JSON 파싱 → embed(알람명/상태전이/사유/리전/시각) → 봇토큰(SSM, 캐시) → Discord REST POST
+- 429 시 `Retry-After` 1회 backoff, 실패 시 raise → SNS 재시도 → DLQ
+- 토큰/Authorization 헤더 **로깅 금지**
+- Heartbeat 모드: SNS Records 없는 이벤트(EventBridge)면 "정상 동작 중" 메시지
+
+### 4.5 Self-monitoring
+- Heartbeat: EventBridge `rate(1 day)` → Lambda → Discord 핑
+- Lambda Errors > 0 Alarm → `webbb-ops`(이메일)
+- DLQ(SQS) + depth>0 Alarm → `webbb-ops`
+
+### 4.6 IaC
+- 단일 CloudFormation 템플릿 `infra/monitoring/cloudwatch-discord-alerts.yaml`
+- 봇 토큰 값은 템플릿에 미포함 (SSM에 사전 등록)
+
+## 5. 보안 하드닝 (봇 토큰 유지에 따른)
+- 토큰: SSM SecureString `/webbb/monitoring/discord-bot-token`
+- Lambda IAM 최소권한: `ssm:GetParameter`는 **해당 파라미터 ARN으로만**, `kms:Decrypt`는 `kms:ViaService=ssm.<region>.amazonaws.com` 조건으로만, Logs 기본 + DLQ `sqs:SendMessage`만
+- 봇은 서버 멤버십 + 채널 `SEND_MESSAGES` 권한 필요
+- 어떤 로그/embed에도 토큰·민감정보 미포함
+
+## 6. Step 0 — 배포 런타임 분기 (구현 1단계, 1줄 확인)
+EC2 안에서 `hostname` 확인 후 한 번만 판별. 결과별 로그 수집:
+
+| 런타임 | 로그 수집 | 앱 영향 | Agent |
+|---|---|---|---|
+| Docker | `awslogs` 로그 드라이버 (컨테이너 STDOUT 직결) | 없음 | 불필요 (권장) |
+| systemd + journald | Agent journald 수집 | 없음(진짜 무수정) | 필요 |
+| systemd(파일) / nohup | `logging.file.name` 1줄 or `nohup.out` + Agent file tail | yml 1줄(코드 아님) | 필요 |
+
+## 7. Free Tier 비용 (codex 정정 반영)
+- 알람 ~4개(CPU/로그/LambdaErrors/DLQ) < 10 alarm metrics 무료
+- 커스텀 메트릭 1개(AppErrorCount) < 10개 무료
+- Lambda/SNS/SQS/EventBridge/SSM(standard)/KMS(aws/ssm, 20k req/월): 사용량 극소 → 실질 0 수렴 ("완전 무료" 단정은 회피)
+- **유일한 비용 리스크**: CloudWatch Logs 5GB/월 초과 → Retention 14d + ERROR 위주 수집으로 방어
+
+## 8. 미해결 / 배포 시 확정
+1. 배포 런타임/로그 경로 (Step 0)
+2. 리전 / InstanceId (Step 0 메타데이터)
+3. 예외/키워드 실제 패턴 + 멀티라인 검증
+4. CPU/로그 임계치 최종값 (운영 튜닝)
+5. 봇 서버/채널 권한 + 토큰 확보
+6. self-monitoring 이메일 주소
+
+## 9. e2e 검증 절차 (배포 후 필수)
+- 합성 에러: 매칭 패턴 N+1회 로그 주입 → 5분 내 Discord 도달 → OK 복귀 확인
+- 합성 CPU: 부하 발생 → CPU 알람 발화
+- Heartbeat: 스케줄 수동 트리거 → Discord 핑
+- 실패경로: 봇 토큰 일시 무효화 → DLQ 적재 + webbb-ops 이메일 도달

--- a/docs/superpowers/specs/2026-06-05-ec2-cpu-log-discord-alerts-design.md
+++ b/docs/superpowers/specs/2026-06-05-ec2-cpu-log-discord-alerts-design.md
@@ -9,7 +9,7 @@
 
 1. **CPU 피크 알림**: EC2 CPU가 지속적으로 높으면 알림.
 2. **로그 반복 알림**: 특정 예외/키워드가 일정 시간 내 N회 이상이면 알림.
-3. 두 알림 모두 **Discord 채널 `1512246623642718308`** 에 **이대리 봇**으로 게시.
+3. 두 알림 모두 **Discord 채널 `1512246623642718308`** 에 **이대리 웹훅**으로 게시.
 
 ## 2. 아키텍처
 
@@ -25,9 +25,9 @@
                                                          │
    CPU·로그 Alarm ──(ALARM/OK)──► [SNS: webbb-alerts] ──► [Lambda(py3.12) 변환기]
                                                               │ timeout 8s, 429 backoff
-                                                              │ 봇토큰=SSM SecureString
+                                                              │ 웹훅URL=SSM SecureString
                                                               ▼
-                                  POST /channels/1512246623642718308/messages (Bot)
+                                  POST {Discord 웹훅 URL}  (username=이대리)
                                                               │ 실패(async 2회 재시도 후)
                                                               ▼  [DLQ(SQS)]
    [Self-monitoring]
@@ -35,14 +35,14 @@
    · Lambda Errors / DLQ depth Alarm ──► [SNS: webbb-ops] ──► 이메일 (Discord와 분리된 경로)
 ```
 
-**핵심 사실**: SNS는 Discord로 직접 전송 불가(SNS는 email/SMS/HTTP(S)/SQS/Lambda만 지원, Discord 봇 REST 포맷과 불일치) → **Lambda 변환기 필수**. (codex 확인)
+**핵심 사실**: SNS는 Discord로 직접 전송 불가(SNS는 email/SMS/HTTP(S)/SQS/Lambda만 지원, Discord 웹훅 JSON 포맷과 불일치 — SNS HTTP 구독은 자체 봉투 포맷+confirm 핸드셰이크) → **Lambda 변환기 필수**. (codex 확인)
 
 ## 3. 설계 결정 및 근거
 
 | 결정 | 내용 | 근거 |
 |---|---|---|
-| Discord 전송 | **이대리 봇 토큰** (Webhook 아님) | 사용자 결정. 리뷰어 3인은 Webhook 권고했으나, 봇 유지 시 §5 하드닝으로 위험 상쇄 |
-| 봇 토큰 보관 | SSM Parameter Store **SecureString** | Secrets Manager는 유료. SSM standard + aws/ssm 키는 Free Tier |
+| Discord 전송 | **이대리 웹훅(Webhook)** | 봇이 없는 것으로 확인 → 웹훅 채택. 리뷰어 3인 권고와 일치, 레포 기존 PR 알림도 웹훅 사용. 토큰·서버멤버십·채널권한 불필요 |
+| 웹훅 URL 보관 | SSM Parameter Store **SecureString** | Secrets Manager는 유료. SSM standard + aws/ssm 키는 Free Tier |
 | CPU 알람 정책 | EvaluationPeriods 3 / Datapoints 2 | 순간 출렁임(flapping) 억제. 로그 알람과 정책 분리 (architect) |
 | 로그 알람 정책 | Sum≥N / Period300 / Eval1 / Datapoints1 | "5분 내 N회" 의미와 일치 (codex 권장값) |
 | 멀티라인 | Agent `multi_line_start_pattern` | Java 스택트레이스를 1이벤트로 → 예외 1건=1카운트 (B3) |
@@ -70,9 +70,9 @@
 
 ### 4.4 Lambda 변환기 (Python 3.12)
 - 트리거 SNS(`webbb-alerts`), timeout 8s, urllib만
-- SNS→CloudWatch Alarm JSON 파싱 → embed(알람명/상태전이/사유/리전/시각) → 봇토큰(SSM, 캐시) → Discord REST POST
+- SNS→CloudWatch Alarm JSON 파싱 → embed(알람명/상태전이/사유/리전/시각) → 웹훅URL(SSM, 캐시) → Discord 웹훅 POST(username=이대리)
 - 429 시 `Retry-After` 1회 backoff, 실패 시 raise → SNS 재시도 → DLQ
-- 토큰/Authorization 헤더 **로깅 금지**
+- 웹훅 URL **로깅 금지** (URL 자체가 시크릿)
 - Heartbeat 모드: SNS Records 없는 이벤트(EventBridge)면 "정상 동작 중" 메시지
 
 ### 4.5 Self-monitoring
@@ -82,13 +82,13 @@
 
 ### 4.6 IaC
 - 단일 CloudFormation 템플릿 `infra/monitoring/cloudwatch-discord-alerts.yaml`
-- 봇 토큰 값은 템플릿에 미포함 (SSM에 사전 등록)
+- 웹훅 URL 값은 템플릿에 미포함 (SSM에 사전 등록)
 
-## 5. 보안 하드닝 (봇 토큰 유지에 따른)
-- 토큰: SSM SecureString `/webbb/monitoring/discord-bot-token`
+## 5. 보안 하드닝 (웹훅 URL)
+- 웹훅 URL: SSM SecureString `/webbb/monitoring/discord-webhook-url`
 - Lambda IAM 최소권한: `ssm:GetParameter`는 **해당 파라미터 ARN으로만**, `kms:Decrypt`는 `kms:ViaService=ssm.<region>.amazonaws.com` 조건으로만, Logs 기본 + DLQ `sqs:SendMessage`만
-- 봇은 서버 멤버십 + 채널 `SEND_MESSAGES` 권한 필요
-- 어떤 로그/embed에도 토큰·민감정보 미포함
+- 웹훅은 채널이 URL에 종속 → 서버 멤버십/채널 권한 설정 불필요 (봇 대비 폭발 반경 작음)
+- 어떤 로그/embed에도 웹훅 URL·민감정보 미포함
 
 ## 6. Step 0 — 배포 런타임 분기 (구현 1단계, 1줄 확인)
 EC2 안에서 `hostname` 확인 후 한 번만 판별. 결과별 로그 수집:
@@ -110,11 +110,11 @@ EC2 안에서 `hostname` 확인 후 한 번만 판별. 결과별 로그 수집:
 2. 리전 / InstanceId (Step 0 메타데이터)
 3. 예외/키워드 실제 패턴 + 멀티라인 검증
 4. CPU/로그 임계치 최종값 (운영 튜닝)
-5. 봇 서버/채널 권한 + 토큰 확보
+5. 채널 `1512246623642718308`에 웹훅 생성 + URL 확보
 6. self-monitoring 이메일 주소
 
 ## 9. e2e 검증 절차 (배포 후 필수)
 - 합성 에러: 매칭 패턴 N+1회 로그 주입 → 5분 내 Discord 도달 → OK 복귀 확인
 - 합성 CPU: 부하 발생 → CPU 알람 발화
 - Heartbeat: 스케줄 수동 트리거 → Discord 핑
-- 실패경로: 봇 토큰 일시 무효화 → DLQ 적재 + webbb-ops 이메일 도달
+- 실패경로: 웹훅 URL 일시 무효화 → DLQ 적재 + webbb-ops 이메일 도달

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,0 +1,197 @@
+# WEBBB 모니터링 알림 (EC2 CPU/로그 → Discord)
+
+EC2 **CPU 피크** 와 **앱 예외/키워드 로그 N회 반복** 을 감지해 **Discord 채널(이대리 봇)** 로 알림을 보냅니다.
+codex + omc(architect/critic) 3중 리뷰를 반영했고, **AWS Free Tier** 범위로 설계했습니다.
+
+> 설계 배경/근거: [docs/superpowers/specs/2026-06-05-ec2-cpu-log-discord-alerts-design.md](../../docs/superpowers/specs/2026-06-05-ec2-cpu-log-discord-alerts-design.md)
+
+## 구성 파일
+| 파일 | 용도 |
+|---|---|
+| `cloudwatch-discord-alerts.yaml` | CloudFormation 템플릿(SNS·Lambda·알람·DLQ·Heartbeat 전부) |
+| `lambda/discord_notifier.py` | Discord 전송 Lambda 소스(템플릿 인라인본과 동일) |
+| `amazon-cloudwatch-agent.json` | EC2 로그를 CloudWatch로 보낼 때 쓰는 Agent 설정 |
+
+---
+
+## 한눈에 보는 흐름
+```
+CPU 알람 ┐
+        ├─ SNS(webbb-alerts) ─ Lambda ─ Discord(이대리 봇, 채널 1512246623642718308)
+로그 알람 ┘                        └ 실패 시 DLQ
+Heartbeat(1일1회) ─ Lambda ─ Discord "정상 동작 중"
+Lambda/DLQ 장애 ─ SNS(webbb-ops) ─ 이메일   ← Discord와 분리된 경로
+```
+
+---
+
+## STEP 0. 런타임 확인 (딱 1번, 인스턴스 내부에서)
+
+**브라우저**에서 AWS 콘솔 → EC2 → 인스턴스 선택 → `연결` → **Session Manager** → 검은 터미널이 열리면 거기서:
+
+```bash
+hostname            # ip-... 로 나오면 EC2 안(정상). juneseok... 면 아직 내 맥임
+sudo docker ps      # WEBBB 컨테이너가 보이면 => Docker 런타임
+systemctl list-units --type=service --state=running | grep -i webbb   # 보이면 => systemd 런타임
+TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds:60')
+curl -s -H "X-aws-ec2-metadata-token:$TOKEN" http://169.254.169.254/latest/meta-data/instance-id; echo
+curl -s -H "X-aws-ec2-metadata-token:$TOKEN" http://169.254.169.254/latest/meta-data/placement/region; echo
+```
+
+확인 결과로 **InstanceId / Region / 런타임(Docker·systemd·nohup)** 을 메모해 둡니다.
+
+---
+
+## STEP 1. 로그를 CloudWatch로 보내기 (런타임별, 택1)
+
+> 목표: 앱 로그가 로그 그룹 `/webbb/app` 으로 들어가게 한다. (CPU 알람은 이 단계 없이도 동작)
+
+### A) Docker 런타임 — Agent 불필요, `awslogs` 드라이버 사용 (가장 단순)
+컨테이너 실행 시 로그 드라이버를 awslogs로:
+```bash
+docker run ... \
+  --log-driver=awslogs \
+  --log-opt awslogs-region=<REGION> \
+  --log-opt awslogs-group=/webbb/app \
+  --log-opt awslogs-create-group=false \
+  --log-opt 'awslogs-multiline-pattern=^\d{4}-\d{2}-\d{2}'
+```
+docker-compose면:
+```yaml
+services:
+  app:
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: "<REGION>"
+        awslogs-group: "/webbb/app"
+        awslogs-multiline-pattern: '^\d{4}-\d{2}-\d{2}'
+```
+→ **EC2 인스턴스 역할(instance profile)** 에 `logs:CreateLogStream`, `logs:PutLogEvents` 권한 필요.
+
+### B) systemd 런타임 — stdout을 파일로 돌리고 CloudWatch Agent로 tail
+1. 유닛 파일(`/etc/systemd/system/webbb.service` 등)에 한 줄 추가(앱 Java 코드 무수정):
+   ```ini
+   [Service]
+   StandardOutput=append:/var/log/webbb/app.log
+   StandardError=append:/var/log/webbb/app.log
+   ```
+   `sudo systemctl daemon-reload && sudo systemctl restart webbb`
+2. CloudWatch Agent 설치 + 설정(아래 "Agent 설치" 참고).
+
+### C) nohup 런타임 — nohup.out 을 Agent로 tail
+- `amazon-cloudwatch-agent.json` 의 `file_path` 를 실제 `nohup.out` 경로로 바꾸고 Agent 설치.
+
+### CloudWatch Agent 설치 (B/C 공통)
+```bash
+sudo yum install -y amazon-cloudwatch-agent        # Amazon Linux (Ubuntu는 .deb)
+sudo mkdir -p /var/log/webbb
+# 이 레포의 amazon-cloudwatch-agent.json 을 /opt/aws/amazon-cloudwatch-agent/etc/ 에 복사 후:
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config -m ec2 -s \
+  -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+```
+→ EC2 인스턴스 역할에 `CloudWatchAgentServerPolicy` 부착 필요.
+
+> 멀티라인(`^\d{4}-\d{2}-\d{2}`)은 Java 스택트레이스를 1개 이벤트로 묶어 "예외 1건=1카운트"를 보장합니다. **실제 로그 첫 줄 형식이 다르면 이 정규식을 맞춰주세요.**
+
+---
+
+## STEP 2. Discord 봇 토큰을 SSM에 저장 (1번)
+토큰 값은 템플릿에 넣지 않습니다. 콘솔: **Systems Manager → 파라미터 스토어 → 파라미터 생성**
+- 이름: `/webbb/monitoring/discord-bot-token`
+- 유형: **SecureString** (KMS 키: `alias/aws/ssm` 기본)
+- 값: 이대리 봇 토큰
+
+> 이대리 봇이 대상 서버에 있고, 채널 `1512246623642718308` 에 **메시지 보내기** 권한이 있어야 합니다.
+
+---
+
+## STEP 3. CloudFormation 스택 배포
+
+### 방법 ① 콘솔 (CLI 막혀 있을 때 권장)
+1. 콘솔 → **CloudFormation → 스택 생성 → 새 리소스 사용**
+2. "템플릿 파일 업로드" → `cloudwatch-discord-alerts.yaml` 선택 → 다음
+3. 파라미터 입력:
+   - `InstanceId`: STEP 0에서 확인한 값
+   - `OpsEmail`: 파이프라인 장애 통보 받을 이메일
+   - 나머지(채널ID·토큰파라미터명·임계치)는 기본값 확인/조정
+4. 다음 → **"IAM 리소스를 생성할 수 있음" 체크** → 스택 생성
+5. 상태가 `CREATE_COMPLETE` 면 완료
+
+### 방법 ② CLI (aws login 권한 풀리면)
+```bash
+aws cloudformation deploy \
+  --stack-name webbb-monitoring \
+  --template-file infra/monitoring/cloudwatch-discord-alerts.yaml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --region <REGION> \
+  --parameter-overrides InstanceId=<i-xxxx> OpsEmail=<you@example.com>
+```
+
+---
+
+## STEP 4. 이메일 구독 확인
+배포 후 `OpsEmail` 주소로 **SNS 구독 확인 메일**이 옵니다 → **Confirm subscription** 클릭. (안 하면 ops 알림 안 옴)
+
+---
+
+## STEP 5. 동작 검증 (e2e)
+1. **로그 알람**: EC2에서 매칭 패턴을 임계치+1회 로그파일에 주입
+   ```bash
+   for i in $(seq 1 11); do echo "$(date '+%Y-%m-%d %H:%M:%S') ERROR test alarm $i" | sudo tee -a /var/log/webbb/app.log >/dev/null; done
+   ```
+   → 5분 내 Discord에 🔴 알림 → 멈추면 🟢 OK 알림 확인
+2. **CPU 알람**: `sudo yum install -y stress && stress --cpu 2 --timeout 600` → CPU 알람 발화 확인
+3. **Heartbeat**: 콘솔 Lambda → `webbb-discord-notifier` → 테스트 이벤트 `{}` 실행 → Discord "✅ 정상 동작 중"
+4. **실패 경로**: SSM 토큰을 잠깐 틀린 값으로 → 알람 1건 유발 → DLQ 적재 + ops 이메일 도착 확인 → 토큰 복구
+
+---
+
+## 비용 (Free Tier) — codex 독립 검증 완료, 정상 운영 시 $0
+- **보유만으로 과금되는 리소스 없음.** 기대는 한도는 대부분 **영구 무료(always-free)** → 가입 1년 뒤에도 $0
+- 알람 5개(<10) · 커스텀 메트릭 1개(<10) · Lambda/SNS/SQS/EventBridge/SSM(standard)/KMS(aws/ssm) 사용량 극소
+- **유일한 변수 = CloudWatch Logs 수집 5GB/월** (앱 로그 + Lambda 자체 실행 로그 합산)
+  - 비용 핵심은 **수집(ingestion, ~$0.76/GB)**. ⚠️ **보관기간(retention)은 "저장"만 줄일 뿐 수집량과 무관** — 7일로 줄여도 수집 5GB 한도 방어엔 효과 없음
+  - 방어책(이미 반영): `LogIngestionBudgetAlarm`(일 ~120MB 초과 시 ops 이메일 조기경보) + Lambda 로그그룹 보관 14일 + **ERROR 위주 수집**
+- 안전 조건(템플릿이 이미 충족): SSM=Standard, KMS=aws/ssm 관리형키, Lambda=VPC 밖, 알람≤10, 메트릭 dimension 추가 금지
+- EC2 **상세 모니터링(1분)은 켜지 말 것**(유료). 기본 5분 사용.
+
+## 로그 수집량(ingestion) 줄이기 — 비용의 유일한 변수
+> 무료 5GB/월 ≈ **166MB/일**. 초기 앱이면 INFO를 다 보내도 그 밑일 가능성이 큼.
+> 원칙: **먼저 배포 → `LogIngestionBudgetAlarm` 으로 관찰 → 울리면 줄이기.** 미리 과최적화 금지.
+
+### 1순위: ERROR(또는 WARN+ERROR)만 CloudWatch로 (전체 로그는 인스턴스 디스크에 유지)
+- 예외/키워드 알림이 목적이면 **ERROR-only가 최적** (자바 예외=ERROR로 찍힘). WARN 신호도 알림받고 싶을 때만 WARN 포함.
+- 적용: `logback-spring.xml.example` → `src/main/resources/logback-spring.xml` 로 복사 (Java 코드 아님, 로깅 설정)
+  - ERROR만: `ThresholdFilter` `<level>ERROR</level>` (예시 기본값)
+  - WARN 포함: `<level>WARN</level>` 로 한 줄 변경
+- `amazon-cloudwatch-agent.json` 의 `file_path` 를 `/var/log/webbb/error.log` 로 변경
+- → CloudWatch엔 에러만 수집(급감). 로그 알람(`?ERROR ?Exception`)은 그대로 동작.
+- ⚠️ **OutOfMemoryError** 는 JVM이 죽으며 로그를 못 남길 수 있음 → 메모리 메트릭/heartbeat로 별도 감지.
+
+### 런타임별 주의
+- **Agent(file tail · systemd/nohup)**: 위 방식 그대로 — 에러 파일만 tail. 가장 효과적.
+- **Docker(awslogs)**: awslogs는 stdout 전체를 전송(레벨 필터 불가) → 둘 중 하나:
+  - (a) prod 로그 레벨을 WARN/ERROR로 올려 stdout 자체를 줄이기 (application-prod.yml 또는 위 logback)
+  - (b) awslogs 대신 "에러 파일 + Agent file tail" 로 전환
+
+### 2순위: 노이즈 로거 낮추기 (INFO 유지하면서도 효과)
+`application-prod.yml`(또는 위 logback)에서 최대 노이즈원부터:
+```
+logging.level.org.hibernate.SQL: WARN        # SQL 로깅 off (보통 가장 큰 노이즈)
+logging.level.org.springframework.web: WARN
+```
++ ALB 헬스체크 / actuator `/health` 핑 로그 제외.
+
+### 측정 (배포 후)
+CloudWatch → Metrics → `AWS/Logs > IncomingBytes`(LogGroupName=`/webbb/app`)로 일별 수집량 확인.
+`LogIngestionBudgetAlarm` 이 일 ~120MB 초과 시 자동으로 ops 이메일 경고.
+
+## 제거
+콘솔 CloudFormation에서 `webbb-monitoring` 스택 삭제. 단, **SSM 봇 토큰 파라미터**와 (awslogs로 만든) 로그 그룹은 별도 정리.
+
+## 조정 포인트
+- 예외/키워드 패턴: 템플릿 `ErrorFilterPattern` (실측 로그로 콘솔 "패턴 테스트" 후 확정)
+- 임계치: `CpuThreshold`, `ErrorThreshold`
+- Lambda 코드 수정 시: `lambda/discord_notifier.py` 와 템플릿 인라인본을 **함께** 갱신

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,6 +1,6 @@
 # WEBBB 모니터링 알림 (EC2 CPU/로그 → Discord)
 
-EC2 **CPU 피크** 와 **앱 예외/키워드 로그 N회 반복** 을 감지해 **Discord 채널(이대리 봇)** 로 알림을 보냅니다.
+EC2 **CPU 피크** 와 **앱 예외/키워드 로그 N회 반복** 을 감지해 **Discord 채널(이대리 웹훅)** 로 알림을 보냅니다.
 codex + omc(architect/critic) 3중 리뷰를 반영했고, **AWS Free Tier** 범위로 설계했습니다.
 
 > 설계 배경/근거: [docs/superpowers/specs/2026-06-05-ec2-cpu-log-discord-alerts-design.md](../../docs/superpowers/specs/2026-06-05-ec2-cpu-log-discord-alerts-design.md)
@@ -17,7 +17,7 @@ codex + omc(architect/critic) 3중 리뷰를 반영했고, **AWS Free Tier** 범
 ## 한눈에 보는 흐름
 ```
 CPU 알람 ┐
-        ├─ SNS(webbb-alerts) ─ Lambda ─ Discord(이대리 봇, 채널 1512246623642718308)
+        ├─ SNS(webbb-alerts) ─ Lambda ─ Discord(이대리 웹훅, 채널 1512246623642718308)
 로그 알람 ┘                        └ 실패 시 DLQ
 Heartbeat(1일1회) ─ Lambda ─ Discord "정상 동작 중"
 Lambda/DLQ 장애 ─ SNS(webbb-ops) ─ 이메일   ← Discord와 분리된 경로
@@ -97,13 +97,20 @@ sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
 
 ---
 
-## STEP 2. Discord 봇 토큰을 SSM에 저장 (1번)
-토큰 값은 템플릿에 넣지 않습니다. 콘솔: **Systems Manager → 파라미터 스토어 → 파라미터 생성**
-- 이름: `/webbb/monitoring/discord-bot-token`
-- 유형: **SecureString** (KMS 키: `alias/aws/ssm` 기본)
-- 값: 이대리 봇 토큰
+## STEP 2. Discord 웹훅 URL을 SSM에 저장 (1번)
 
-> 이대리 봇이 대상 서버에 있고, 채널 `1512246623642718308` 에 **메시지 보내기** 권한이 있어야 합니다.
+### 2-1. 채널에 웹훅 만들기 (봇 불필요)
+Discord에서 채널 `1512246623642718308` → **채널 편집(톱니) → 연동(Integrations) → 웹후크 → 새 웹후크**
+- 이름: `이대리` (표시 이름)
+- **웹후크 URL 복사** (`https://discord.com/api/webhooks/...` 형태, 이게 시크릿)
+
+### 2-2. URL을 SSM에 저장
+URL 값은 템플릿에 넣지 않습니다. 콘솔: **Systems Manager → 파라미터 스토어 → 파라미터 생성**
+- 이름: `/webbb/monitoring/discord-webhook-url`
+- 계층: **표준(Standard)** / 유형: **SecureString** (KMS 키 `alias/aws/ssm` 기본)
+- 값: 위에서 복사한 웹후크 URL
+
+> 웹훅은 채널이 URL에 포함되어 있어 봇 토큰·서버 멤버십·채널 권한 설정이 모두 불필요합니다. (Lambda가 `username`을 `이대리`로 표시)
 
 ---
 
@@ -115,7 +122,7 @@ sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
 3. 파라미터 입력:
    - `InstanceId`: STEP 0에서 확인한 값
    - `OpsEmail`: 파이프라인 장애 통보 받을 이메일
-   - 나머지(채널ID·토큰파라미터명·임계치)는 기본값 확인/조정
+   - 나머지(웹훅 파라미터명·임계치)는 기본값 확인/조정
 4. 다음 → **"IAM 리소스를 생성할 수 있음" 체크** → 스택 생성
 5. 상태가 `CREATE_COMPLETE` 면 완료
 
@@ -144,7 +151,7 @@ aws cloudformation deploy \
    → 5분 내 Discord에 🔴 알림 → 멈추면 🟢 OK 알림 확인
 2. **CPU 알람**: `sudo yum install -y stress && stress --cpu 2 --timeout 600` → CPU 알람 발화 확인
 3. **Heartbeat**: 콘솔 Lambda → `webbb-discord-notifier` → 테스트 이벤트 `{}` 실행 → Discord "✅ 정상 동작 중"
-4. **실패 경로**: SSM 토큰을 잠깐 틀린 값으로 → 알람 1건 유발 → DLQ 적재 + ops 이메일 도착 확인 → 토큰 복구
+4. **실패 경로**: SSM 웹훅 URL을 잠깐 틀린 값으로 → 알람 1건 유발 → DLQ 적재 + ops 이메일 도착 확인 → URL 복구
 
 ---
 
@@ -189,7 +196,7 @@ CloudWatch → Metrics → `AWS/Logs > IncomingBytes`(LogGroupName=`/webbb/app`)
 `LogIngestionBudgetAlarm` 이 일 ~120MB 초과 시 자동으로 ops 이메일 경고.
 
 ## 제거
-콘솔 CloudFormation에서 `webbb-monitoring` 스택 삭제. 단, **SSM 봇 토큰 파라미터**와 (awslogs로 만든) 로그 그룹은 별도 정리.
+콘솔 CloudFormation에서 `webbb-monitoring` 스택 삭제. 단, **SSM 웹훅 URL 파라미터**와 (awslogs로 만든) 로그 그룹은 별도 정리.
 
 ## 조정 포인트
 - 예외/키워드 패턴: 템플릿 `ErrorFilterPattern` (실측 로그로 콘솔 "패턴 테스트" 후 확정)

--- a/infra/monitoring/amazon-cloudwatch-agent.json
+++ b/infra/monitoring/amazon-cloudwatch-agent.json
@@ -1,0 +1,21 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root"
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/webbb/app.log",
+            "log_group_name": "/webbb/app",
+            "log_stream_name": "{instance_id}",
+            "timezone": "Local",
+            "multi_line_start_pattern": "^\\d{4}-\\d{2}-\\d{2}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/infra/monitoring/cloudwatch-discord-alerts.yaml
+++ b/infra/monitoring/cloudwatch-discord-alerts.yaml
@@ -1,21 +1,21 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   WEBBB 모니터링 알림 - EC2 CPU 피크 + 앱 예외/키워드 로그 N회 반복을
-  SNS -> Lambda -> Discord(이대리 봇)로 통합 전송. self-monitoring(Heartbeat/DLQ/이메일) 포함.
+  SNS -> Lambda -> Discord(이대리 웹훅)으로 통합 전송. self-monitoring(Heartbeat/DLQ/이메일) 포함.
   codex + omc(architect/critic) 3중 리뷰 반영. Free Tier 범위.
 
 Parameters:
   InstanceId:
     Type: String
     Description: CPU 알람 대상 EC2 인스턴스 ID (예 i-0abc123...). Step 0 메타데이터로 확인.
-  DiscordChannelId:
+  WebhookUrlSsmParam:
     Type: String
-    Default: "1512246623642718308"
-    Description: 알림을 게시할 Discord 채널 ID
-  BotTokenSsmParam:
+    Default: "/webbb/monitoring/discord-webhook-url"
+    Description: Discord 웹훅 URL이 저장된 SSM SecureString 파라미터 이름(값은 사전 등록). 채널은 웹훅 URL에 포함됨.
+  WebhookUsername:
     Type: String
-    Default: "/webbb/monitoring/discord-bot-token"
-    Description: 이대리 봇 토큰이 저장된 SSM SecureString 파라미터 이름(값은 사전 등록)
+    Default: "이대리"
+    Description: Discord에 표시될 이름(웹훅 username override)
   AppLogGroupName:
     Type: String
     Default: "/webbb/app"
@@ -92,10 +92,10 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
-              - Sid: ReadBotToken
+              - Sid: ReadWebhookUrl
                 Effect: Allow
                 Action: ssm:GetParameter
-                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${BotTokenSsmParam}"
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${WebhookUrlSsmParam}"
               - Sid: DecryptViaSsmOnly
                 Effect: Allow
                 Action: kms:Decrypt
@@ -130,27 +130,26 @@ Resources:
         TargetArn: !GetAtt NotifierDLQ.Arn
       Environment:
         Variables:
-          CHANNEL_ID: !Ref DiscordChannelId
-          TOKEN_PARAM: !Ref BotTokenSsmParam
+          WEBHOOK_PARAM: !Ref WebhookUrlSsmParam
+          WEBHOOK_USERNAME: !Ref WebhookUsername
       Code:
         ZipFile: |
           import json, os, time, urllib.error, urllib.request
           import boto3
           _ssm = boto3.client("ssm")
-          _tok = {}
+          _wh = {}
 
-          def _token():
-              if "v" not in _tok:
-                  r = _ssm.get_parameter(Name=os.environ["TOKEN_PARAM"], WithDecryption=True)
-                  _tok["v"] = r["Parameter"]["Value"]
-              return _tok["v"]
+          def _webhook():
+              if "v" not in _wh:
+                  r = _ssm.get_parameter(Name=os.environ["WEBHOOK_PARAM"], WithDecryption=True)
+                  _wh["v"] = r["Parameter"]["Value"]
+              return _wh["v"]
 
-          def _post(channel, payload):
-              url = "https://discord.com/api/v10/channels/%s/messages" % channel
+          def _post(payload):
+              payload.setdefault("username", os.environ.get("WEBHOOK_USERNAME", "이대리"))
               req = urllib.request.Request(
-                  url, data=json.dumps(payload).encode("utf-8"), method="POST",
-                  headers={"Authorization": "Bot " + _token(),
-                           "Content-Type": "application/json",
+                  _webhook(), data=json.dumps(payload).encode("utf-8"), method="POST",
+                  headers={"Content-Type": "application/json",
                            "User-Agent": "webbb-monitor/1.0"})
               try:
                   with urllib.request.urlopen(req, timeout=8) as r:
@@ -175,16 +174,15 @@ Resources:
                              {"name": "시각", "value": a.get("StateChangeTime", "-"), "inline": False}]}]}
 
           def handler(event, context):
-              ch = os.environ["CHANNEL_ID"]
               if not event.get("Records"):
-                  _post(ch, {"content": "✅ WEBBB 모니터링 정상 동작 중 (heartbeat)"})
+                  _post({"content": "✅ WEBBB 모니터링 정상 동작 중 (heartbeat)"})
                   return {"ok": True, "mode": "heartbeat"}
               for rec in event["Records"]:
                   msg = rec.get("Sns", {}).get("Message", "")
                   try:
-                      _post(ch, _embed(json.loads(msg)))
+                      _post(_embed(json.loads(msg)))
                   except (ValueError, TypeError):
-                      _post(ch, {"content": "⚠️ " + str(msg)[:1800]})
+                      _post({"content": "⚠️ " + str(msg)[:1800]})
               return {"ok": True, "mode": "alarm", "count": len(event["Records"])}
 
   PermitSnsInvoke:

--- a/infra/monitoring/cloudwatch-discord-alerts.yaml
+++ b/infra/monitoring/cloudwatch-discord-alerts.yaml
@@ -1,0 +1,346 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  WEBBB 모니터링 알림 - EC2 CPU 피크 + 앱 예외/키워드 로그 N회 반복을
+  SNS -> Lambda -> Discord(이대리 봇)로 통합 전송. self-monitoring(Heartbeat/DLQ/이메일) 포함.
+  codex + omc(architect/critic) 3중 리뷰 반영. Free Tier 범위.
+
+Parameters:
+  InstanceId:
+    Type: String
+    Description: CPU 알람 대상 EC2 인스턴스 ID (예 i-0abc123...). Step 0 메타데이터로 확인.
+  DiscordChannelId:
+    Type: String
+    Default: "1512246623642718308"
+    Description: 알림을 게시할 Discord 채널 ID
+  BotTokenSsmParam:
+    Type: String
+    Default: "/webbb/monitoring/discord-bot-token"
+    Description: 이대리 봇 토큰이 저장된 SSM SecureString 파라미터 이름(값은 사전 등록)
+  AppLogGroupName:
+    Type: String
+    Default: "/webbb/app"
+    Description: 앱 로그가 수집될 CloudWatch Logs 로그 그룹 이름
+  LogRetentionInDays:
+    Type: Number
+    Default: 14
+    Description: 로그 "저장" 보관 기간(일). 저장비/디버깅 이력용. (수집 5GB 한도와는 무관)
+  DailyLogBytesThreshold:
+    Type: Number
+    Default: 120000000
+    Description: >
+      일일 로그 "수집량"(byte)이 이 값을 넘으면 ops 이메일 경보.
+      기본 120MB/일 ≈ 3.6GB/월 → 무료 수집 5GB 넘기기 전에 미리 경고.
+  ErrorFilterPattern:
+    Type: String
+    Default: "?ERROR ?Exception"
+    Description: 로그 카운트 필터 패턴. 실측 로그로 콘솔 Test Pattern 검증 후 조정.
+  ErrorThreshold:
+    Type: Number
+    Default: 10
+    Description: 5분간 이 횟수 이상이면 로그 알람 발화
+  CpuThreshold:
+    Type: Number
+    Default: 80
+    Description: 이 % 이상(평균)이면 CPU 알람 발화
+  OpsEmail:
+    Type: String
+    Description: 파이프라인 자체 장애(Lambda/DLQ) 통보용 이메일 (Discord와 분리 경로)
+
+Resources:
+  # ───────────── SNS ─────────────
+  AlertsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: webbb-alerts
+      DisplayName: WEBBB Alerts
+
+  OpsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: webbb-ops
+      DisplayName: WEBBB Ops (pipeline self-monitoring)
+
+  OpsEmailSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Ref OpsTopic
+      Protocol: email
+      Endpoint: !Ref OpsEmail
+
+  # ───────────── DLQ ─────────────
+  NotifierDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: webbb-discord-notifier-dlq
+      MessageRetentionPeriod: 1209600  # 14일
+
+  # ───────────── Lambda 변환기 ─────────────
+  NotifierRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: webbb-discord-notifier-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: lambda.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: webbb-notifier-least-privilege
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: ReadBotToken
+                Effect: Allow
+                Action: ssm:GetParameter
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${BotTokenSsmParam}"
+              - Sid: DecryptViaSsmOnly
+                Effect: Allow
+                Action: kms:Decrypt
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    kms:ViaService: !Sub "ssm.${AWS::Region}.amazonaws.com"
+              - Sid: SendToDLQ
+                Effect: Allow
+                Action: sqs:SendMessage
+                Resource: !GetAtt NotifierDLQ.Arn
+
+  # Lambda 자체 실행 로그 그룹 - 명시 생성으로 보관기간 지정(기본은 무기한 → 누적 방지).
+  # Lambda 실행 로그도 같은 CloudWatch Logs 5GB 수집 한도에 합산되므로 함께 관리.
+  NotifierLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/webbb-discord-notifier
+      RetentionInDays: !Ref LogRetentionInDays
+
+  NotifierFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: NotifierLogGroup
+    Properties:
+      FunctionName: webbb-discord-notifier
+      Runtime: python3.12
+      Handler: index.handler
+      Timeout: 8
+      MemorySize: 128
+      Role: !GetAtt NotifierRole.Arn
+      DeadLetterConfig:
+        TargetArn: !GetAtt NotifierDLQ.Arn
+      Environment:
+        Variables:
+          CHANNEL_ID: !Ref DiscordChannelId
+          TOKEN_PARAM: !Ref BotTokenSsmParam
+      Code:
+        ZipFile: |
+          import json, os, time, urllib.error, urllib.request
+          import boto3
+          _ssm = boto3.client("ssm")
+          _tok = {}
+
+          def _token():
+              if "v" not in _tok:
+                  r = _ssm.get_parameter(Name=os.environ["TOKEN_PARAM"], WithDecryption=True)
+                  _tok["v"] = r["Parameter"]["Value"]
+              return _tok["v"]
+
+          def _post(channel, payload):
+              url = "https://discord.com/api/v10/channels/%s/messages" % channel
+              req = urllib.request.Request(
+                  url, data=json.dumps(payload).encode("utf-8"), method="POST",
+                  headers={"Authorization": "Bot " + _token(),
+                           "Content-Type": "application/json",
+                           "User-Agent": "webbb-monitor/1.0"})
+              try:
+                  with urllib.request.urlopen(req, timeout=8) as r:
+                      return r.status
+              except urllib.error.HTTPError as e:
+                  if e.code == 429:
+                      time.sleep(min(float(e.headers.get("Retry-After", "1") or "1"), 5))
+                      with urllib.request.urlopen(req, timeout=8) as r:
+                          return r.status
+                  raise
+
+          def _embed(a):
+              s = a.get("NewStateValue", "")
+              color = 15158332 if s == "ALARM" else (5763719 if s == "OK" else 15844367)
+              icon = "🔴 " if s == "ALARM" else "🟢 " if s == "OK" else "🟡 "
+              title = (icon + a.get("AlarmName", "(unknown)"))[:250]
+              region = a.get("Region") or os.environ.get("AWS_REGION", "")
+              return {"embeds": [{"title": title,
+                  "description": (a.get("NewStateReason") or "")[:1500], "color": color,
+                  "fields": [{"name": "상태", "value": s or "-", "inline": True},
+                             {"name": "리전", "value": region or "-", "inline": True},
+                             {"name": "시각", "value": a.get("StateChangeTime", "-"), "inline": False}]}]}
+
+          def handler(event, context):
+              ch = os.environ["CHANNEL_ID"]
+              if not event.get("Records"):
+                  _post(ch, {"content": "✅ WEBBB 모니터링 정상 동작 중 (heartbeat)"})
+                  return {"ok": True, "mode": "heartbeat"}
+              for rec in event["Records"]:
+                  msg = rec.get("Sns", {}).get("Message", "")
+                  try:
+                      _post(ch, _embed(json.loads(msg)))
+                  except (ValueError, TypeError):
+                      _post(ch, {"content": "⚠️ " + str(msg)[:1800]})
+              return {"ok": True, "mode": "alarm", "count": len(event["Records"])}
+
+  PermitSnsInvoke:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref NotifierFunction
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref AlertsTopic
+
+  AlertsToLambda:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: lambda
+      Endpoint: !GetAtt NotifierFunction.Arn
+
+  # ───────────── Heartbeat (데드맨 스위치) ─────────────
+  HeartbeatRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: webbb-monitor-heartbeat
+      ScheduleExpression: rate(1 day)
+      State: ENABLED
+      Targets:
+        - Id: notifier
+          Arn: !GetAtt NotifierFunction.Arn
+          Input: '{"heartbeat": true}'
+
+  PermitEventsInvoke:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref NotifierFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt HeartbeatRule.Arn
+
+  # ───────────── 로그: LogGroup + Metric Filter ─────────────
+  AppLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Ref AppLogGroupName
+      RetentionInDays: !Ref LogRetentionInDays
+
+  ErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref AppLogGroup
+      FilterPattern: !Ref ErrorFilterPattern
+      MetricTransformations:
+        - MetricName: AppErrorCount
+          MetricNamespace: WEBBB/App
+          MetricValue: "1"
+          DefaultValue: 0
+
+  # ───────────── 알람 ─────────────
+  CpuAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: webbb-ec2-cpu-high
+      AlarmDescription: !Sub "EC2 ${InstanceId} CPU 평균 ${CpuThreshold}% 이상 (5분*3 중 2)"
+      Namespace: AWS/EC2
+      MetricName: CPUUtilization
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref InstanceId
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
+      Threshold: !Ref CpuThreshold
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertsTopic]
+      OKActions: [!Ref AlertsTopic]
+
+  LogErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: webbb-app-errors-high
+      AlarmDescription: !Sub "앱 예외/키워드 로그 5분간 ${ErrorThreshold}회 이상"
+      Namespace: WEBBB/App
+      MetricName: AppErrorCount
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: !Ref ErrorThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertsTopic]
+      OKActions: [!Ref AlertsTopic]
+
+  LambdaErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: webbb-notifier-lambda-errors
+      AlarmDescription: "Discord 전송 Lambda 실패 - 파이프라인 자체 장애(이메일 경로)"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref NotifierFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsTopic]
+
+  DlqDepthAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: webbb-notifier-dlq-depth
+      AlarmDescription: "DLQ에 미전송 알림 적재 - 이메일 경로"
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt NotifierDLQ.QueueName
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsTopic]
+
+  # 비용 방어: 일일 로그 "수집량"이 임계 초과 시 ops 이메일 경고 (5GB/월 넘기기 전 조기경보)
+  LogIngestionBudgetAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: webbb-log-ingestion-budget
+      AlarmDescription: !Sub "로그 수집량 일일 ${DailyLogBytesThreshold} byte 초과 - Free Tier 5GB/월 초과 위험(이메일 경로)"
+      Namespace: AWS/Logs
+      MetricName: IncomingBytes
+      Dimensions:
+        - Name: LogGroupName
+          Value: !Ref AppLogGroupName
+      Statistic: Sum
+      Period: 86400
+      EvaluationPeriods: 1
+      Threshold: !Ref DailyLogBytesThreshold
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref OpsTopic]
+
+Outputs:
+  AlertsTopicArn:
+    Value: !Ref AlertsTopic
+  OpsTopicArn:
+    Value: !Ref OpsTopic
+  NotifierFunctionName:
+    Value: !Ref NotifierFunction
+  AppLogGroup:
+    Value: !Ref AppLogGroup
+  DLQUrl:
+    Value: !Ref NotifierDLQ

--- a/infra/monitoring/lambda/discord_notifier.py
+++ b/infra/monitoring/lambda/discord_notifier.py
@@ -1,15 +1,16 @@
 """
-SNS(CloudWatch Alarm) → Discord 변환기 Lambda.
+SNS(CloudWatch Alarm) → Discord 웹훅 변환기 Lambda.
 
 - 트리거: SNS 토픽 webbb-alerts (CPU/로그 알람)
 - 또는: EventBridge 스케줄(SNS Records 없음) → Heartbeat(데드맨 스위치) 메시지
 - 의존성: 없음 (urllib + boto3는 Lambda 기본 제공)
 
 환경변수:
-  CHANNEL_ID    : Discord 채널 ID (예: 1512246623642718308)
-  TOKEN_PARAM   : 봇 토큰이 저장된 SSM 파라미터 이름 (SecureString)
+  WEBHOOK_PARAM    : Discord 웹훅 URL이 저장된 SSM 파라미터 이름 (SecureString)
+  WEBHOOK_USERNAME : Discord에 표시할 이름 (예: 이대리)
 
-주의: 봇 토큰/Authorization 헤더는 절대 로깅하지 않는다.
+주의: 웹훅 URL은 그 자체가 시크릿이다. 로깅하지 않는다.
+      채널은 웹훅 URL에 포함되므로 채널 ID를 따로 지정하지 않는다.
 
 이 파일은 CloudFormation 템플릿(cloudwatch-discord-alerts.yaml)의
 인라인 Lambda 코드와 동일하게 유지한다(source of truth).
@@ -24,26 +25,26 @@ import urllib.request
 import boto3
 
 _ssm = boto3.client("ssm")
-_token_cache = {}
+_webhook_cache = {}
 
 
-def _get_token():
-    if "v" not in _token_cache:
-        name = os.environ["TOKEN_PARAM"]
+def _get_webhook():
+    if "v" not in _webhook_cache:
+        name = os.environ["WEBHOOK_PARAM"]
         resp = _ssm.get_parameter(Name=name, WithDecryption=True)
-        _token_cache["v"] = resp["Parameter"]["Value"]
-    return _token_cache["v"]
+        _webhook_cache["v"] = resp["Parameter"]["Value"]
+    return _webhook_cache["v"]
 
 
-def _post(channel_id, payload):
-    url = "https://discord.com/api/v10/channels/%s/messages" % channel_id
+def _post(payload):
+    # 웹훅 username override 로 '이대리' 브랜딩 유지
+    payload.setdefault("username", os.environ.get("WEBHOOK_USERNAME", "이대리"))
     body = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
-        url,
+        _get_webhook(),
         data=body,
         method="POST",
         headers={
-            "Authorization": "Bot " + _get_token(),
             "Content-Type": "application/json",
             "User-Agent": "webbb-monitor/1.0",
         },
@@ -86,11 +87,9 @@ def _embed(alarm):
 
 
 def handler(event, context):
-    channel_id = os.environ["CHANNEL_ID"]
-
     # Heartbeat: SNS Records가 없으면 EventBridge 스케줄 호출로 간주
     if not event.get("Records"):
-        _post(channel_id, {"content": "✅ WEBBB 모니터링 정상 동작 중 (heartbeat)"})
+        _post({"content": "✅ WEBBB 모니터링 정상 동작 중 (heartbeat)"})
         return {"ok": True, "mode": "heartbeat"}
 
     for rec in event["Records"]:
@@ -98,8 +97,8 @@ def handler(event, context):
         try:
             alarm = json.loads(message)
         except (ValueError, TypeError):
-            _post(channel_id, {"content": "⚠️ " + str(message)[:1800]})
+            _post({"content": "⚠️ " + str(message)[:1800]})
             continue
-        _post(channel_id, _embed(alarm))
+        _post(_embed(alarm))
 
     return {"ok": True, "mode": "alarm", "count": len(event["Records"])}

--- a/infra/monitoring/lambda/discord_notifier.py
+++ b/infra/monitoring/lambda/discord_notifier.py
@@ -1,0 +1,105 @@
+"""
+SNS(CloudWatch Alarm) → Discord 변환기 Lambda.
+
+- 트리거: SNS 토픽 webbb-alerts (CPU/로그 알람)
+- 또는: EventBridge 스케줄(SNS Records 없음) → Heartbeat(데드맨 스위치) 메시지
+- 의존성: 없음 (urllib + boto3는 Lambda 기본 제공)
+
+환경변수:
+  CHANNEL_ID    : Discord 채널 ID (예: 1512246623642718308)
+  TOKEN_PARAM   : 봇 토큰이 저장된 SSM 파라미터 이름 (SecureString)
+
+주의: 봇 토큰/Authorization 헤더는 절대 로깅하지 않는다.
+
+이 파일은 CloudFormation 템플릿(cloudwatch-discord-alerts.yaml)의
+인라인 Lambda 코드와 동일하게 유지한다(source of truth).
+"""
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+import boto3
+
+_ssm = boto3.client("ssm")
+_token_cache = {}
+
+
+def _get_token():
+    if "v" not in _token_cache:
+        name = os.environ["TOKEN_PARAM"]
+        resp = _ssm.get_parameter(Name=name, WithDecryption=True)
+        _token_cache["v"] = resp["Parameter"]["Value"]
+    return _token_cache["v"]
+
+
+def _post(channel_id, payload):
+    url = "https://discord.com/api/v10/channels/%s/messages" % channel_id
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": "Bot " + _get_token(),
+            "Content-Type": "application/json",
+            "User-Agent": "webbb-monitor/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=8) as r:
+            return r.status
+    except urllib.error.HTTPError as e:
+        # 429 Too Many Requests → Retry-After 만큼 1회 대기 후 재시도
+        if e.code == 429:
+            retry_after = float(e.headers.get("Retry-After", "1") or "1")
+            time.sleep(min(retry_after, 5))
+            with urllib.request.urlopen(req, timeout=8) as r:
+                return r.status
+        raise  # 그 외 실패는 raise → SNS 재시도 → DLQ
+
+
+def _embed(alarm):
+    state = alarm.get("NewStateValue", "")
+    color = 15158332 if state == "ALARM" else (5763719 if state == "OK" else 15844367)
+    name = alarm.get("AlarmName", "(unknown)")
+    reason = (alarm.get("NewStateReason") or "")[:1500]
+    region = alarm.get("Region") or os.environ.get("AWS_REGION", "")
+    when = alarm.get("StateChangeTime", "")
+    title = ("🔴 " if state == "ALARM" else "🟢 " if state == "OK" else "🟡 ") + name
+    return {
+        "embeds": [
+            {
+                "title": title[:250],
+                "description": reason,
+                "color": color,
+                "fields": [
+                    {"name": "상태", "value": state or "-", "inline": True},
+                    {"name": "리전", "value": region or "-", "inline": True},
+                    {"name": "시각", "value": when or "-", "inline": False},
+                ],
+            }
+        ]
+    }
+
+
+def handler(event, context):
+    channel_id = os.environ["CHANNEL_ID"]
+
+    # Heartbeat: SNS Records가 없으면 EventBridge 스케줄 호출로 간주
+    if not event.get("Records"):
+        _post(channel_id, {"content": "✅ WEBBB 모니터링 정상 동작 중 (heartbeat)"})
+        return {"ok": True, "mode": "heartbeat"}
+
+    for rec in event["Records"]:
+        message = rec.get("Sns", {}).get("Message", "")
+        try:
+            alarm = json.loads(message)
+        except (ValueError, TypeError):
+            _post(channel_id, {"content": "⚠️ " + str(message)[:1800]})
+            continue
+        _post(channel_id, _embed(alarm))
+
+    return {"ok": True, "mode": "alarm", "count": len(event["Records"])}

--- a/infra/monitoring/logback-spring.xml.example
+++ b/infra/monitoring/logback-spring.xml.example
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  [선택] CloudWatch Logs 수집량(ingestion) 절감용 logback 예시.
+
+  목적: WARN/ERROR 만 별도 파일(/var/log/webbb/error.log)로 남기고,
+        CloudWatch Agent는 "그 에러 파일만" 수집 → 수집량을 INFO 제외로 대폭 절감.
+        (전체 로그는 콘솔/기존 경로에 그대로 → 인스턴스에서 디버깅 가능)
+
+  적용 방법(선택 시):
+    1) 이 파일을 src/main/resources/logback-spring.xml 로 복사
+    2) amazon-cloudwatch-agent.json 의 file_path 를 /var/log/webbb/error.log 로 변경
+    3) 재배포
+
+  주의: 이건 "Java 코드"가 아니라 로깅 "설정"입니다. 앱 도메인/레이어 코드는 건드리지 않습니다.
+        Docker(awslogs 드라이버)로 stdout 전체를 보내는 구성에서는 이 방식 대신
+        application-prod.yml 의 로그 레벨 조정(아래 README 참고)을 사용하세요.
+-->
+<configuration>
+  <!-- Spring Boot 기본 콘솔 포맷/색상 유지 (기존 동작 보존) -->
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+  <!-- ERROR 만 담는 파일 (CloudWatch 수집 대상). 수집량 최소화. -->
+  <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>/var/log/webbb/error.log</file>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <!-- ERROR 만 통과(가장 저렴). WARN 신호도 알림받으려면 ERROR -> WARN 으로 변경 -->
+      <level>ERROR</level>
+    </filter>
+    <!-- 첫 줄이 타임스탬프로 시작 → Agent multi_line_start_pattern "^\d{4}-\d{2}-\d{2}" 과 일치 -->
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>/var/log/webbb/error.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>7</maxHistory>   <!-- 디스크에는 7일치만 -->
+    </rollingPolicy>
+  </appender>
+
+  <!-- 노이즈 큰 로거는 prod 에서 WARN 으로 낮춰 수집량 추가 절감 -->
+  <springProfile name="prod">
+    <logger name="org.hibernate.SQL" level="WARN"/>
+    <logger name="org.springframework.web" level="WARN"/>
+    <logger name="org.springframework.security" level="WARN"/>
+  </springProfile>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>     <!-- 전체 로그: 콘솔(디버깅용) -->
+    <appender-ref ref="ERROR_FILE"/>  <!-- WARN+ERROR: 파일(CloudWatch 수집) -->
+  </root>
+</configuration>


### PR DESCRIPTION
## 개요
EC2 **CPU 피크** 와 **앱 예외/키워드 로그 N회 반복** 을 감지해 **Discord 채널(이대리 봇)** 로 통합 알림하는 모니터링 인프라(IaC)를 추가합니다. **앱(Java) 코드는 전혀 건드리지 않고 `infra/` 에만 추가**했습니다.

## 변경 사항
| 파일 | 내용 |
|---|---|
| `infra/monitoring/cloudwatch-discord-alerts.yaml` | CloudFormation 템플릿 (SNS·Lambda·알람·DLQ·Heartbeat, 18 리소스) |
| `infra/monitoring/lambda/discord_notifier.py` | SNS→Discord 변환 Lambda (urllib 무의존, 429 backoff) |
| `infra/monitoring/amazon-cloudwatch-agent.json` | EC2 로그 수집 설정 (멀티라인 스택트레이스 병합) |
| `infra/monitoring/logback-spring.xml.example` | ERROR-only 수집으로 로그 ingestion 절감 (선택 적용) |
| `infra/monitoring/README.md` | 콘솔 기준 배포 가이드 + Free Tier 비용 분석 |
| `docs/superpowers/specs/2026-06-05-...md` | 설계서 (codex + omc 3중 리뷰 반영) |

## 아키텍처
`CPU 알람 / 로그 알람 → SNS(webbb-alerts) → Lambda → Discord(이대리 봇)` , 실패 시 DLQ.
파이프라인 자체 장애(Lambda/DLQ)는 **별도 경로(SNS webbb-ops → 이메일)** 로 — 자기장애 루프 차단.

## 리뷰 반영 포인트
- 봇 토큰: SSM SecureString + IAM 최소권한(파라미터 ARN으로만 `ssm:GetParameter`)
- 멀티라인 병합으로 예외 1건=1카운트 (false positive 방지)
- self-monitoring: Heartbeat(데드맨 스위치) + DLQ + 로그 수집량 경보
- CPU 알람은 3주기 중 2 (flapping 억제), LogGroup 보관 14일(비용 방어)

## DDD / 레이어 영향
- **없음.** 인프라(CFN/Lambda/Agent)만 추가, 도메인·application·interface 코드 무변경. 의존 방향 변화 없음.
- (선택) `logback-spring.xml.example` 적용 시에도 로깅 "설정"이지 도메인 코드 아님.

## 테스트 / 확인
- `cfn-lint` 통과 (에러/경고 0)
- 인라인 Lambda 코드 2257/4096 bytes (S3 패키징 불필요), 컴파일 OK
- Lambda 로직 5개 케이스 로컬 모의 통과 (ALARM/OK/Heartbeat/비정상메시지/토큰 비노출)

## 남은 배포 단계 (수동, README 참조)
> ⚠️ 이 PR 머지만으로는 AWS에 리소스가 생기지 않습니다. 아래는 권한 가진 사람이 콘솔에서 수행:
1. 봇 토큰을 SSM `/webbb/monitoring/discord-bot-token`(SecureString)에 저장
2. CloudFormation에 템플릿 업로드 → 스택 생성 (params: `InstanceId=i-0fe5aca1503579606`, `OpsEmail=<이메일>`, 나머지 기본값)
3. ops 이메일 구독 확인 → CPU 부하/합성 에러로 e2e 검증

## Free Tier 비용
정상 운영 시 $0 (codex 독립 검증). 유일 변수는 CloudWatch Logs 수집 5GB/월 → 보관기간·ERROR 위주 수집·수집량 경보로 방어.

## 리뷰어 집중 포인트
- `cloudwatch-discord-alerts.yaml` 의 IAM 권한 범위 / 알람 임계치 / 리전(ap-northeast-2) 적합성
- 로그 패턴 `?ERROR ?Exception` 이 실제 prod 로그와 맞는지(배포 시 콘솔 Test Pattern 검증 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)