### PR TITLE
feat(mypage): 몬스터 통계 API 구현

### DIFF
--- a/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
@@ -175,7 +175,7 @@ public class SwaggerConfig {
 
         put(statuses, ApiImplementationStatus.STUB, "GET", "/api/me/posts");
         put(statuses, ApiImplementationStatus.STUB, "GET", "/api/me/comments");
-        put(statuses, ApiImplementationStatus.STUB, "GET", "/api/me/monster-stats");
+        put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/me/monster-stats");
 
         return Map.copyOf(statuses);
     }

--- a/src/main/java/com/ddd/webbb/monster/application/MonsterService.java
+++ b/src/main/java/com/ddd/webbb/monster/application/MonsterService.java
@@ -48,6 +48,10 @@ public class MonsterService {
         return monsterRepository.findByPost_IdIn(postIds);
     }
 
+    public List<Monster> findByUserId(Long userId) {
+        return monsterRepository.findByPost_UserIdAndPost_IsDeletedFalse(userId);
+    }
+
     @Transactional
     public Monster addMonster(Post post, EmotionType emotionType, int hp) {
         return monsterRepository.save(Monster.create(post, emotionType, normalizeHp(hp)));

--- a/src/main/java/com/ddd/webbb/monster/domain/MonsterRepository.java
+++ b/src/main/java/com/ddd/webbb/monster/domain/MonsterRepository.java
@@ -10,4 +10,6 @@ public interface MonsterRepository extends JpaRepository<Monster, Long> {
     Optional<Monster> findByPost_Id(Long postId);
 
     List<Monster> findByPost_IdIn(List<Long> postIds);
+
+    List<Monster> findByPost_UserIdAndPost_IsDeletedFalse(Long userId);
 }

--- a/src/main/java/com/ddd/webbb/mypage/application/MyPageService.java
+++ b/src/main/java/com/ddd/webbb/mypage/application/MyPageService.java
@@ -1,0 +1,55 @@
+package com.ddd.webbb.mypage.application;
+
+import com.ddd.webbb.emotion.domain.EmotionType;
+import com.ddd.webbb.monster.application.MonsterService;
+import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.monster.domain.MonsterStatus;
+import com.ddd.webbb.mypage.interfaces.dto.MonsterStatsResponse;
+import com.ddd.webbb.user.application.UserService;
+import com.ddd.webbb.user.domain.User;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+
+    private final MonsterService monsterService;
+    private final UserService userService;
+
+    public MonsterStatsResponse getMonsterStats(UUID publicId) {
+        User user = userService.getUserEntity(publicId);
+        List<Monster> monsters = monsterService.findByUserId(user.getId());
+
+        int total = monsters.size();
+        int defeated =
+                (int) monsters.stream().filter(m -> m.getStatus() == MonsterStatus.DEAD).count();
+
+        MonsterStatsResponse.MostFrequentEmotion mostFrequent = buildMostFrequent(monsters, total);
+        return new MonsterStatsResponse(total, defeated, mostFrequent);
+    }
+
+    private MonsterStatsResponse.MostFrequentEmotion buildMostFrequent(
+            List<Monster> monsters, int total) {
+        if (monsters.isEmpty()) {
+            return null;
+        }
+        Map<EmotionType, Long> freq =
+                monsters.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        Monster::getEmotionType, Collectors.counting()));
+        EmotionType top = Collections.max(freq.entrySet(), Map.Entry.comparingByValue()).getKey();
+        int topCount = freq.get(top).intValue();
+        int percentage = (int) Math.round(topCount * 100.0 / total);
+        return new MonsterStatsResponse.MostFrequentEmotion(
+                top.name(), top.getDisplayName(), topCount, percentage);
+    }
+}

--- a/src/main/java/com/ddd/webbb/mypage/interfaces/MyPageController.java
+++ b/src/main/java/com/ddd/webbb/mypage/interfaces/MyPageController.java
@@ -1,6 +1,8 @@
 package com.ddd.webbb.mypage.interfaces;
 
 import com.ddd.webbb.global.common.response.ApiResponse;
+import com.ddd.webbb.global.security.CustomUserPrincipal;
+import com.ddd.webbb.mypage.application.MyPageService;
 import com.ddd.webbb.mypage.interfaces.dto.MonsterStatsResponse;
 import com.ddd.webbb.mypage.interfaces.dto.MyCommentResponse;
 import com.ddd.webbb.mypage.interfaces.dto.MyPostResponse;
@@ -12,6 +14,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,8 +23,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "MyPage", description = "마이페이지 API")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/me")
 public class MyPageController {
+
+    private final MyPageService myPageService;
 
     @Operation(summary = "내가 작성한 게시글 목록 조회")
     @ApiResponses({
@@ -104,11 +111,67 @@ public class MyPageController {
         return ApiResponse.ok("내 댓글 목록을 조회했습니다.", new MyCommentResponse(List.of(comment), null));
     }
 
-    @Operation(summary = "몬스터 통계 조회")
+    @Operation(
+            summary = "몬스터 통계 조회",
+            description =
+                    "로그인한 사용자의 마이페이지 몬스터 통계를 반환합니다.\n\n"
+                            + "응답 필드 설명:\n"
+                            + "- totalMonsterCount: 사용자가 작성한 게시글에 생성된 전체 몬스터 수\n"
+                            + "- defeatedMonsterCount: 공감·댓글로 HP가 0이 되어 처치된 몬스터 수\n"
+                            + "- mostFrequentEmotion: 가장 많이 나타난 감정 유형 정보\n"
+                            + "  - 몬스터가 하나도 없으면 null → 프론트에서 '두드러진 감정이 없어요' 표시\n"
+                            + "  - type: 감정 enum (ANXIETY=불안, LETHARGY=무기력, LONELINESS=외로움, "
+                            + "SELF_DEPRECATION=자기비하, IRRITATION=짜증)\n"
+                            + "  - percentage: 전체 몬스터 중 해당 감정의 비율 (0~100, 반올림)\n\n"
+                            + "인증 필요: Authorization 헤더에 Bearer Access Token을 포함해야 합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
                 description = "몬스터 통계 조회 성공",
+                content =
+                        @Content(
+                                examples = {
+                                    @ExampleObject(
+                                            name = "감정 데이터 있음",
+                                            summary = "몬스터가 존재하고 최다 감정이 있는 경우",
+                                            value =
+                                                    """
+                        {
+                          "success": true,
+                          "message": "몬스터 통계를 조회했습니다.",
+                          "data": {
+                            "totalMonsterCount": 5,
+                            "defeatedMonsterCount": 3,
+                            "mostFrequentEmotion": {
+                              "type": "ANXIETY",
+                              "displayName": "불안",
+                              "count": 2,
+                              "percentage": 40
+                            }
+                          },
+                          "timestamp": "2026-06-11T10:00:00"
+                        }
+                        """),
+                                    @ExampleObject(
+                                            name = "감정 데이터 없음",
+                                            summary = "아직 게시글을 작성하지 않아 몬스터가 없는 경우",
+                                            value =
+                                                    """
+                        {
+                          "success": true,
+                          "message": "몬스터 통계를 조회했습니다.",
+                          "data": {
+                            "totalMonsterCount": 0,
+                            "defeatedMonsterCount": 0,
+                            "mostFrequentEmotion": null
+                          },
+                          "timestamp": "2026-06-11T10:00:00"
+                        }
+                        """)
+                                })),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "인증 실패 또는 Access Token 누락",
                 content =
                         @Content(
                                 examples =
@@ -116,22 +179,16 @@ public class MyPageController {
                                                 value =
                                                         """
                         {
-                          "success": true,
-                          "message": "몬스터 통계를 조회했습니다.",
-                          "data": {
-                            "totalMonsterCount": 5,
-                            "defeatedMonsterCount": 3,
-                            "mostFrequentEmotion": { "type": "ANXIETY", "displayName": "불안", "count": 3 }
-                          },
-                          "timestamp": "2026-04-27T21:00:00"
+                          "success": false,
+                          "message": "인증이 필요합니다.",
+                          "timestamp": "2026-06-11T10:00:00"
                         }
                         """)))
     })
     @GetMapping("/monster-stats")
-    public ApiResponse<MonsterStatsResponse> getMonsterStats() {
-        // TODO: 실제 서비스 연동
-        MonsterStatsResponse.MostFrequentEmotion emotion =
-                new MonsterStatsResponse.MostFrequentEmotion("ANXIETY", "불안", 3);
-        return ApiResponse.ok("몬스터 통계를 조회했습니다.", new MonsterStatsResponse(5, 3, emotion));
+    public ApiResponse<MonsterStatsResponse> getMonsterStats(
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        return ApiResponse.ok(
+                "몬스터 통계를 조회했습니다.", myPageService.getMonsterStats(principal.publicId()));
     }
 }

--- a/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MonsterStatsResponse.java
+++ b/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MonsterStatsResponse.java
@@ -1,7 +1,32 @@
 package com.ddd.webbb.mypage.interfaces.dto;
 
-public record MonsterStatsResponse(
-        int totalMonsterCount, int defeatedMonsterCount, MostFrequentEmotion mostFrequentEmotion) {
+import io.swagger.v3.oas.annotations.media.Schema;
 
-    public record MostFrequentEmotion(String type, String displayName, int count) {}
+@Schema(description = "마이페이지 몬스터 통계 응답")
+public record MonsterStatsResponse(
+        @Schema(description = "사용자가 작성한 게시글에 생성된 전체 몬스터 수", example = "5") int totalMonsterCount,
+        @Schema(description = "HP가 0이 되어 처치된 몬스터 수", example = "3") int defeatedMonsterCount,
+        @Schema(
+                        description =
+                                "가장 많이 나타난 감정 유형 정보. 게시글에 몬스터가 하나도 없으면 null이며, "
+                                        + "프론트에서는 null일 때 '두드러진 감정이 없어요'를 표시한다.",
+                        nullable = true)
+                MostFrequentEmotion mostFrequentEmotion) {
+
+    @Schema(description = "최다 빈도 감정 유형 상세")
+    public record MostFrequentEmotion(
+            @Schema(
+                            description =
+                                    "감정 타입 enum. "
+                                            + "ANXIETY=불안, "
+                                            + "LETHARGY=무기력, "
+                                            + "LONELINESS=외로움, "
+                                            + "SELF_DEPRECATION=자기비하, "
+                                            + "IRRITATION=짜증",
+                            example = "ANXIETY")
+                    String type,
+            @Schema(description = "감정 한국어 표시명", example = "불안") String displayName,
+            @Schema(description = "해당 감정 타입 몬스터 수", example = "2") int count,
+            @Schema(description = "전체 몬스터 중 해당 감정의 비율 (0~100, 반올림)", example = "40")
+                    int percentage) {}
 }

--- a/src/test/java/com/ddd/webbb/mypage/application/MyPageServiceTest.java
+++ b/src/test/java/com/ddd/webbb/mypage/application/MyPageServiceTest.java
@@ -1,0 +1,96 @@
+package com.ddd.webbb.mypage.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.ddd.webbb.category.domain.BoardCategory;
+import com.ddd.webbb.emotion.domain.EmotionType;
+import com.ddd.webbb.monster.application.MonsterService;
+import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.mypage.interfaces.dto.MonsterStatsResponse;
+import com.ddd.webbb.post.domain.CommentTone;
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.user.application.UserService;
+import com.ddd.webbb.user.domain.User;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MyPageServiceTest {
+
+    private MonsterService monsterService;
+    private UserService userService;
+    private MyPageService myPageService;
+
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        monsterService = mock(MonsterService.class);
+        userService = mock(UserService.class);
+        myPageService = new MyPageService(monsterService, userService);
+
+        User user = User.create("ogu@test.com", "오구");
+        BoardCategory category = BoardCategory.create("멘탈케어", "기본 카테고리", 0);
+        post = Post.create(user, category, "title", "content", CommentTone.COMFORT_ME);
+    }
+
+    @Test
+    @DisplayName("몬스터가 없으면 전체 0, 물리친 0, 최빈 감정 null을 반환한다")
+    void noMonsters_returnsZeroAndNullEmotion() {
+        User user = User.create("ogu@test.com", "오구");
+        given(userService.getUserEntity(any(UUID.class))).willReturn(user);
+        given(monsterService.findByUserId(any())).willReturn(List.of());
+
+        MonsterStatsResponse result = myPageService.getMonsterStats(UUID.randomUUID());
+
+        assertThat(result.totalMonsterCount()).isEqualTo(0);
+        assertThat(result.defeatedMonsterCount()).isEqualTo(0);
+        assertThat(result.mostFrequentEmotion()).isNull();
+    }
+
+    @Test
+    @DisplayName("물리친 몬스터 수를 정확히 집계한다")
+    void countsDefeatedMonstersCorrectly() {
+        User user = User.create("ogu@test.com", "오구");
+        given(userService.getUserEntity(any(UUID.class))).willReturn(user);
+
+        Monster alive = Monster.create(post, EmotionType.ANXIETY, 10);
+        Monster dead1 = Monster.create(post, EmotionType.LETHARGY, 10);
+        dead1.decreaseHp(10);
+        Monster dead2 = Monster.create(post, EmotionType.IRRITATION, 10);
+        dead2.decreaseHp(10);
+        given(monsterService.findByUserId(any())).willReturn(List.of(alive, dead1, dead2));
+
+        MonsterStatsResponse result = myPageService.getMonsterStats(UUID.randomUUID());
+
+        assertThat(result.totalMonsterCount()).isEqualTo(3);
+        assertThat(result.defeatedMonsterCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("가장 많이 나타난 감정 타입과 비율을 반환한다")
+    void returnsMostFrequentEmotionWithPercentage() {
+        User user = User.create("ogu@test.com", "오구");
+        given(userService.getUserEntity(any(UUID.class))).willReturn(user);
+
+        Monster a1 = Monster.create(post, EmotionType.ANXIETY, 10);
+        Monster a2 = Monster.create(post, EmotionType.ANXIETY, 10);
+        Monster a3 = Monster.create(post, EmotionType.ANXIETY, 10);
+        Monster l1 = Monster.create(post, EmotionType.LETHARGY, 10);
+        Monster l2 = Monster.create(post, EmotionType.LETHARGY, 10);
+        given(monsterService.findByUserId(any())).willReturn(List.of(a1, a2, a3, l1, l2));
+
+        MonsterStatsResponse result = myPageService.getMonsterStats(UUID.randomUUID());
+
+        assertThat(result.mostFrequentEmotion()).isNotNull();
+        assertThat(result.mostFrequentEmotion().type()).isEqualTo("ANXIETY");
+        assertThat(result.mostFrequentEmotion().displayName()).isEqualTo("불안");
+        assertThat(result.mostFrequentEmotion().count()).isEqualTo(3);
+        assertThat(result.mostFrequentEmotion().percentage()).isEqualTo(60);
+    }
+}

--- a/src/test/java/com/ddd/webbb/mypage/interfaces/MyPageControllerTest.java
+++ b/src/test/java/com/ddd/webbb/mypage/interfaces/MyPageControllerTest.java
@@ -1,0 +1,82 @@
+package com.ddd.webbb.mypage.interfaces;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ddd.webbb.global.auth.CustomOAuth2UserService;
+import com.ddd.webbb.global.auth.JwtAuthFilter;
+import com.ddd.webbb.global.auth.JwtAuthenticationEntryPoint;
+import com.ddd.webbb.global.auth.JwtProvider;
+import com.ddd.webbb.global.auth.OAuth2LoginFailureHandler;
+import com.ddd.webbb.global.auth.OAuth2LoginSuccessHandler;
+import com.ddd.webbb.global.auth.RedisOAuth2AuthorizationRequestRepository;
+import com.ddd.webbb.global.config.SecurityConfig;
+import com.ddd.webbb.global.security.CustomUserPrincipal;
+import com.ddd.webbb.mypage.application.MyPageService;
+import com.ddd.webbb.mypage.interfaces.dto.MonsterStatsResponse;
+import com.ddd.webbb.user.application.UserService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MyPageController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class, JwtAuthenticationEntryPoint.class})
+@ActiveProfiles("test")
+class MyPageControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private MyPageService myPageService;
+    @MockitoBean private UserService userService;
+    @MockitoBean private JwtProvider jwtProvider;
+    @MockitoBean private CustomOAuth2UserService customOAuth2UserService;
+    @MockitoBean private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    @MockitoBean private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    @MockitoBean private RedisOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+    @Test
+    @DisplayName("인증된 사용자가 몬스터 통계를 조회한다")
+    void authenticatedUser_getsMonsterStats() throws Exception {
+        UUID userId = UUID.randomUUID();
+        CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "오구");
+
+        MonsterStatsResponse response =
+                new MonsterStatsResponse(
+                        5, 3, new MonsterStatsResponse.MostFrequentEmotion("ANXIETY", "불안", 2, 40));
+        given(myPageService.getMonsterStats(any(UUID.class))).willReturn(response);
+
+        mockMvc.perform(
+                        get("/api/me/monster-stats")
+                                .with(
+                                        authentication(
+                                                new UsernamePasswordAuthenticationToken(
+                                                        principal, null, List.of()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalMonsterCount").value(5))
+                .andExpect(jsonPath("$.data.defeatedMonsterCount").value(3))
+                .andExpect(jsonPath("$.data.mostFrequentEmotion.type").value("ANXIETY"))
+                .andExpect(jsonPath("$.data.mostFrequentEmotion.displayName").value("불안"))
+                .andExpect(jsonPath("$.data.mostFrequentEmotion.percentage").value(40));
+    }
+
+    @Test
+    @DisplayName("인증 없이 조회하면 401을 반환한다")
+    void unauthenticatedRequest_returns401() throws Exception {
+        mockMvc.perform(get("/api/me/monster-stats"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+}


### PR DESCRIPTION
## PR 제목(내용 요약)
feat(mypage): 마이페이지 몬스터 통계 API 구현

## 📌 변경 내용 & 이유

마이페이지의 `GET /api/me/monster-stats` 엔드포인트가 하드코딩 stub 상태였습니다.
실제 DB 데이터와 연동하고, Swagger 문서도 프론트 연동에 충분한 수준으로 보강했습니다.

**변경 내용**
- `MonsterRepository` — 사용자 ID 기반 몬스터 목록 조회 파생 쿼리 추가 (`findByPost_UserIdAndPost_IsDeletedFalse`)
- `MonsterService` — `findByUserId(Long userId)` public 메서드 추가
- `MyPageService` (신규) — MonsterService·UserService를 조합해 전체 수·처치 수·최다 감정 유형·비율을 집계
- `MyPageController` — `@AuthenticationPrincipal` 추가, stub 제거 후 MyPageService 연동
- `MonsterStatsResponse` — `MostFrequentEmotion`에 `percentage` 필드 추가, 필드별 `@Schema` 설명 추가
- `SwaggerConfig` — `/api/me/monster-stats` 상태 레이블 `STUB → LIVE`

**Swagger 문서 보강**
- `@Operation(description)`: 전체 동작 설명, null 조건, 인증 요건 명시
- `@ExampleObject` 2종: "감정 데이터 있음" / "감정 데이터 없음 (mostFrequentEmotion: null)"
- `401` 응답 추가

## 🧪 테스트 방법

- `./gradlew test` — 전체 테스트 통과 확인
- 추가된 테스트:
  - `MyPageServiceTest` — 몬스터 없음(null 반환), 물리친 수 집계, 최빈 감정+비율 계산 (3케이스)
  - `MyPageControllerTest` — 인증 성공(200), 미인증(401) (2케이스)

## 📢 논의하고 싶은 내용

- `mostFrequentEmotion`이 null일 때 "두드러진 감정이 없어요" 표시는 프론트 처리로 합의했습니다. 다른 조건(예: 특정 비율 미만은 null 처리 등)이 필요하면 논의해 주세요.

## ✅ 체크리스트
- [ ] 엔티티(`@Entity`) 스키마를 변경한 경우 `db/migration/V{N}__*.sql` 파일을 함께 포함했다

## 🧩 관련 이슈
closes #78