### PR TITLE
feat(cicd): 릴리즈 시 운영 자동 배포 및 HTTP 포트 80 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,7 +167,7 @@ jobs:
 
           echo "Waiting for application to start..."
           for i in \$(seq 1 30); do
-            if curl -sf http://localhost:8080/actuator/health > /dev/null 2>&1; then
+            if curl -sf http://localhost:80/actuator/health > /dev/null 2>&1; then
               echo "Application is healthy!"
               exit 0
             fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -81,3 +81,100 @@ jobs:
           push: true
           tags: ${{ steps.tags.outputs.tags }}
 
+  deploy-prod:
+    needs: [release-please, build]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: webbb-ec2-deploy
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image name (lowercase)
+        run: echo "IMAGE_NAME=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Create .env for production
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          DB_URL_PROD: ${{ secrets.DB_URL }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+          NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
+          NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
+          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+        run: |
+          {
+            printf 'GHCR_TOKEN=%s\n' "$GHCR_TOKEN"
+            printf 'GHCR_USERNAME=%s\n' "$GHCR_USERNAME"
+            printf 'GITHUB_REPOSITORY=%s\n' "$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+            printf 'IMAGE_TAG=%s\n' "${{ needs.release-please.outputs.tag_name }}"
+            printf 'DB_URL_PROD=%s\n' "$DB_URL_PROD"
+            printf 'DB_USERNAME=%s\n' "$DB_USERNAME"
+            printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD"
+            printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY"
+            printf 'JWT_SECRET=%s\n' "$JWT_SECRET"
+            printf 'GOOGLE_CLIENT_ID=%s\n' "$GOOGLE_CLIENT_ID"
+            printf 'GOOGLE_CLIENT_SECRET=%s\n' "$GOOGLE_CLIENT_SECRET"
+            printf 'KAKAO_CLIENT_ID=%s\n' "$KAKAO_CLIENT_ID"
+            printf 'KAKAO_CLIENT_SECRET=%s\n' "$KAKAO_CLIENT_SECRET"
+            printf 'NAVER_CLIENT_ID=%s\n' "$NAVER_CLIENT_ID"
+            printf 'NAVER_CLIENT_SECRET=%s\n' "$NAVER_CLIENT_SECRET"
+            printf 'FRONTEND_URL=%s\n' "$FRONTEND_URL"
+          } > .env
+
+      - name: Deploy to EC2
+        env:
+          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+          EC2_USER: ${{ secrets.EC2_USER }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$EC2_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+          COMPOSE_B64=$(base64 -w0 docker-compose.prod.yml)
+          ENV_B64=$(base64 -w0 .env)
+
+          ssh -o StrictHostKeyChecking=no -o ConnectTimeout=60 \
+            -i ~/.ssh/deploy_key "${EC2_USER}@${EC2_HOST}" bash << DEPLOY_EOF
+          set -euo pipefail
+          mkdir -p ~/app && cd ~/app
+
+          echo '${COMPOSE_B64}' | base64 -d > docker-compose.prod.yml
+          echo '${ENV_B64}' | base64 -d > .env
+
+          GHCR_TOKEN=\$(grep '^GHCR_TOKEN=' .env | cut -d= -f2-)
+          GHCR_USERNAME=\$(grep '^GHCR_USERNAME=' .env | cut -d= -f2-)
+          echo "\${GHCR_TOKEN}" | docker login ghcr.io -u "\${GHCR_USERNAME}" --password-stdin
+
+          docker compose --env-file .env -f docker-compose.prod.yml pull app
+          docker compose --env-file .env -f docker-compose.prod.yml up -d
+          docker image prune -f 2>/dev/null || true
+
+          echo "Waiting for application to start..."
+          for i in \$(seq 1 30); do
+            if curl -sf http://localhost:80/actuator/health > /dev/null 2>&1; then
+              echo "Application is healthy!"
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "ERROR: Health check failed after 150 seconds."
+          docker compose -f docker-compose.prod.yml logs app --tail 50
+          docker compose -f docker-compose.prod.yml stop app
+          exit 1
+          DEPLOY_EOF
+
+          rm -f ~/.ssh/deploy_key
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG:-latest}
     container_name: webbb-prod-app
     ports:
-      - "8080:8080"
+      - "80:8080"
     mem_limit: ${APP_MEM_LIMIT:-384m}
     mem_reservation: ${APP_MEM_RESERVATION:-256m}
     cpus: ${APP_CPU_LIMIT:-1.0}


### PR DESCRIPTION
## 📌 변경 내용 & 이유

### 1. 운영 자동 배포 추가 (`release-please.yml`)
기존에는 `main` 머지 후 GHCR에 이미지만 push되고 EC2 배포가 이뤄지지 않는 문제가 있었습니다.
`deploy-prod` 잡을 추가해 릴리즈 PR 머지 시(`release_created=true`) 자동으로 운영 서버에 배포되도록 수정했습니다.

- `needs: [release-please, build]` + `if: release_created == 'true'` 조건
- 릴리즈 태그(`vX.Y.Z`) 이미지를 사용해 배포
- `concurrency: webbb-ec2-deploy`로 중복 배포 방지
- 헬스체크 실패 시 컨테이너 중단 및 워크플로 실패 처리

### 2. HTTP 포트 80 변경 (`docker-compose.prod.yml`)
`http://api.5959.site:8080/` → `http://api.5959.site/` 로 접근 가능하도록 변경했습니다.
Spring Boot는 컨테이너 내부에서 여전히 8080을 사용하고, Docker가 호스트 80 → 컨테이너 8080으로 포워딩합니다.

### 3. 헬스체크 URL 수정 (`deploy.yml`)
포트 변경에 따라 `localhost:8080` → `localhost:80` 으로 수정했습니다.

## 🧪 테스트 방법

1. 이 PR 머지 후 Release Please가 생성한 릴리즈 PR을 머지
2. GitHub Actions에서 `deploy-prod` 잡이 실행되는지 확인
3. EC2에서 `docker ps`로 컨테이너 재시작 확인
4. `http://api.5959.site/` 접근 가능 여부 확인 (EC2 보안 그룹 80 포트 인바운드 허용 필요)

## 📢 논의하고 싶은 내용

- EC2 보안 그룹에서 **80 포트 인바운드 허용** 및 **기존 8080 포트 규칙 제거**는 콘솔에서 직접 처리해야 합니다.

## ✅ 체크리스트
- [x] 엔티티(`@Entity`) 스키마를 변경한 경우 `db/migration/V{N}__*.sql` 파일을 함께 포함했다 (해당 없음)

## 🧩 관련 이슈
Closes #83