### PR TITLE
feat: 게시글 목록 직군·경력 필터링 추가

### DIFF
--- a/src/main/java/com/ddd/webbb/auth/application/AuthService.java
+++ b/src/main/java/com/ddd/webbb/auth/application/AuthService.java
@@ -71,8 +71,8 @@ public class AuthService {
                         request.email(),
                         request.nickname(),
                         encodedPassword,
-                        request.jobRole(),
-                        request.careerYear());
+                        request.jobRole() != null ? request.jobRole().name() : null,
+                        request.careerYear() != null ? request.careerYear().name() : null);
         userRepository.save(user);
 
         AuthToken authToken = issueTokens(user.getPublicId());
@@ -129,7 +129,10 @@ public class AuthService {
 
         User user =
                 User.createOAuthUser(
-                        oauthUserInfo.email(), nickname, request.jobRole(), request.careerYear());
+                        oauthUserInfo.email(),
+                        nickname,
+                        request.jobRole() != null ? request.jobRole().name() : null,
+                        request.careerYear() != null ? request.careerYear().name() : null);
         userRepository.save(user);
 
         UserOauth userOauth =

--- a/src/main/java/com/ddd/webbb/auth/interfaces/AuthController.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/AuthController.java
@@ -44,7 +44,16 @@ public class AuthController {
         this.oAuthCodeStore = oAuthCodeStore;
     }
 
-    @Operation(summary = "SNS 로그인/회원가입")
+    @Operation(
+            summary = "SNS 로그인/회원가입",
+            description =
+                    "신규 OAuth 사용자 생성 시 직군(jobRole)과 경력(careerYear)을 함께 저장할 수 있습니다.\n\n"
+                            + "직군 허용 값: PLANNING(기획), DESIGN(디자인), DEVELOPMENT(개발), MARKETING(마케팅), "
+                            + "SALES(영업), HR(인사), GENERAL_AFFAIRS(총무), PRODUCTION(생산), "
+                            + "ACCOUNTING(회계), OTHER(기타)\n"
+                            + "경력 허용 값: NEWCOMER(신입), YEAR_1(1년차), YEAR_2(2년차), YEAR_3(3년차), "
+                            + "YEAR_4(4년차), YEAR_5(5년차), YEAR_6(6년차), YEAR_7_PLUS(7년차 이상)\n\n"
+                            + "허용 값 외 문자열을 보내면 400 Bad Request를 반환합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -145,7 +154,16 @@ public class AuthController {
                 "토큰 교환에 성공했습니다.", new TokenInfo(tokenPair.accessToken(), tokenPair.refreshToken()));
     }
 
-    @Operation(summary = "이메일 회원가입")
+    @Operation(
+            summary = "이메일 회원가입",
+            description =
+                    "이메일 회원가입 시 직군(jobRole)과 경력(careerYear)을 함께 저장할 수 있습니다.\n\n"
+                            + "직군 허용 값: PLANNING(기획), DESIGN(디자인), DEVELOPMENT(개발), MARKETING(마케팅), "
+                            + "SALES(영업), HR(인사), GENERAL_AFFAIRS(총무), PRODUCTION(생산), "
+                            + "ACCOUNTING(회계), OTHER(기타)\n"
+                            + "경력 허용 값: NEWCOMER(신입), YEAR_1(1년차), YEAR_2(2년차), YEAR_3(3년차), "
+                            + "YEAR_4(4년차), YEAR_5(5년차), YEAR_6(6년차), YEAR_7_PLUS(7년차 이상)\n\n"
+                            + "허용 값 외 문자열을 보내면 400 Bad Request를 반환합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "201",

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailSignupRequest.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailSignupRequest.java
@@ -1,5 +1,7 @@
 package com.ddd.webbb.auth.interfaces.dto;
 
+import com.ddd.webbb.user.domain.CareerLevel;
+import com.ddd.webbb.user.domain.JobType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -18,5 +20,38 @@ public record EmailSignupRequest(
                 @NotBlank(message = "닉네임은 필수입니다.")
                 @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
                 String nickname,
-        @Schema(example = "DEVELOPMENT") String jobRole,
-        @Schema(example = "NEWCOMER") String careerYear) {}
+        @Schema(
+                        description =
+                                "직군. PLANNING=기획, DESIGN=디자인, DEVELOPMENT=개발, MARKETING=마케팅, "
+                                        + "SALES=영업, HR=인사, GENERAL_AFFAIRS=총무, PRODUCTION=생산, "
+                                        + "ACCOUNTING=회계, OTHER=기타",
+                        example = "DEVELOPMENT",
+                        allowableValues = {
+                            "PLANNING",
+                            "DESIGN",
+                            "DEVELOPMENT",
+                            "MARKETING",
+                            "SALES",
+                            "HR",
+                            "GENERAL_AFFAIRS",
+                            "PRODUCTION",
+                            "ACCOUNTING",
+                            "OTHER"
+                        })
+                JobType jobRole,
+        @Schema(
+                        description =
+                                "경력. NEWCOMER=신입, YEAR_1=1년차, YEAR_2=2년차, YEAR_3=3년차, "
+                                        + "YEAR_4=4년차, YEAR_5=5년차, YEAR_6=6년차, YEAR_7_PLUS=7년차 이상",
+                        example = "NEWCOMER",
+                        allowableValues = {
+                            "NEWCOMER",
+                            "YEAR_1",
+                            "YEAR_2",
+                            "YEAR_3",
+                            "YEAR_4",
+                            "YEAR_5",
+                            "YEAR_6",
+                            "YEAR_7_PLUS"
+                        })
+                CareerLevel careerYear) {}

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/OAuthLoginRequest.java
@@ -1,5 +1,7 @@
 package com.ddd.webbb.auth.interfaces.dto;
 
+import com.ddd.webbb.user.domain.CareerLevel;
+import com.ddd.webbb.user.domain.JobType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
@@ -7,5 +9,38 @@ public record OAuthLoginRequest(
         @Schema(example = "provider-access-token") @NotBlank(message = "OAuth 액세스 토큰은 필수입니다.")
                 String oauthAccessToken,
         @Schema(example = "ogu") String nickname,
-        @Schema(example = "DEVELOPMENT") String jobRole,
-        @Schema(example = "YEAR_3") String careerYear) {}
+        @Schema(
+                        description =
+                                "직군. PLANNING=기획, DESIGN=디자인, DEVELOPMENT=개발, MARKETING=마케팅, "
+                                        + "SALES=영업, HR=인사, GENERAL_AFFAIRS=총무, PRODUCTION=생산, "
+                                        + "ACCOUNTING=회계, OTHER=기타",
+                        example = "DEVELOPMENT",
+                        allowableValues = {
+                            "PLANNING",
+                            "DESIGN",
+                            "DEVELOPMENT",
+                            "MARKETING",
+                            "SALES",
+                            "HR",
+                            "GENERAL_AFFAIRS",
+                            "PRODUCTION",
+                            "ACCOUNTING",
+                            "OTHER"
+                        })
+                JobType jobRole,
+        @Schema(
+                        description =
+                                "경력. NEWCOMER=신입, YEAR_1=1년차, YEAR_2=2년차, YEAR_3=3년차, "
+                                        + "YEAR_4=4년차, YEAR_5=5년차, YEAR_6=6년차, YEAR_7_PLUS=7년차 이상",
+                        example = "YEAR_3",
+                        allowableValues = {
+                            "NEWCOMER",
+                            "YEAR_1",
+                            "YEAR_2",
+                            "YEAR_3",
+                            "YEAR_4",
+                            "YEAR_5",
+                            "YEAR_6",
+                            "YEAR_7_PLUS"
+                        })
+                CareerLevel careerYear) {}

--- a/src/main/java/com/ddd/webbb/post/application/PostSearchCondition.java
+++ b/src/main/java/com/ddd/webbb/post/application/PostSearchCondition.java
@@ -1,0 +1,25 @@
+package com.ddd.webbb.post.application;
+
+import java.util.List;
+
+public record PostSearchCondition(List<String> jobRoles, List<String> careerYears) {
+
+    public PostSearchCondition {
+        jobRoles = normalize(jobRoles);
+        careerYears = normalize(careerYears);
+    }
+
+    public static PostSearchCondition empty() {
+        return new PostSearchCondition(List.of(), List.of());
+    }
+
+    private static List<String> normalize(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .toList();
+    }
+}

--- a/src/main/java/com/ddd/webbb/post/application/PostService.java
+++ b/src/main/java/com/ddd/webbb/post/application/PostService.java
@@ -95,7 +95,12 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostListResponse getPosts(Long cursor, int size) {
-        List<Post> fetched = postRepositoryImpl.findByCursor(cursor, size);
+        return getPosts(cursor, size, PostSearchCondition.empty());
+    }
+
+    @Transactional(readOnly = true)
+    public PostListResponse getPosts(Long cursor, int size, PostSearchCondition condition) {
+        List<Post> fetched = postRepositoryImpl.findByCursor(cursor, size, condition);
         boolean hasNext = fetched.size() > size;
         List<Post> posts = hasNext ? fetched.subList(0, size) : fetched;
 

--- a/src/main/java/com/ddd/webbb/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/com/ddd/webbb/post/infrastructure/PostRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.ddd.webbb.post.infrastructure;
 
+import com.ddd.webbb.post.application.PostSearchCondition;
 import com.ddd.webbb.post.domain.Post;
 import com.ddd.webbb.post.domain.QPost;
+import com.ddd.webbb.user.domain.QUser;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import org.springframework.stereotype.Repository;
@@ -16,12 +19,37 @@ public class PostRepositoryImpl {
     }
 
     public List<Post> findByCursor(Long cursor, int size) {
+        return findByCursor(cursor, size, PostSearchCondition.empty());
+    }
+
+    public List<Post> findByCursor(Long cursor, int size, PostSearchCondition condition) {
         QPost post = QPost.post;
+        QUser user = QUser.user;
         return queryFactory
                 .selectFrom(post)
-                .where(post.isDeleted.isFalse(), cursor != null ? post.id.lt(cursor) : null)
+                .join(post.user, user)
+                .fetchJoin()
+                .where(
+                        post.isDeleted.isFalse(),
+                        cursorCondition(post, cursor),
+                        jobRoleCondition(user, condition),
+                        careerYearCondition(user, condition))
                 .orderBy(post.id.desc())
                 .limit(size + 1L)
                 .fetch();
+    }
+
+    private BooleanExpression cursorCondition(QPost post, Long cursor) {
+        return cursor != null ? post.id.lt(cursor) : null;
+    }
+
+    private BooleanExpression jobRoleCondition(QUser user, PostSearchCondition condition) {
+        return condition.jobRoles().isEmpty() ? null : user.jobType.in(condition.jobRoles());
+    }
+
+    private BooleanExpression careerYearCondition(QUser user, PostSearchCondition condition) {
+        return condition.careerYears().isEmpty()
+                ? null
+                : user.careerLevel.in(condition.careerYears());
     }
 }

--- a/src/main/java/com/ddd/webbb/post/interfaces/PostController.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/PostController.java
@@ -2,6 +2,7 @@ package com.ddd.webbb.post.interfaces;
 
 import com.ddd.webbb.global.common.response.ApiResponse;
 import com.ddd.webbb.global.security.CustomUserPrincipal;
+import com.ddd.webbb.post.application.PostSearchCondition;
 import com.ddd.webbb.post.application.PostService;
 import com.ddd.webbb.post.interfaces.dto.PostCreateRequest;
 import com.ddd.webbb.post.interfaces.dto.PostCreateResponse;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -157,7 +159,14 @@ public class PostController {
                 .body(ApiResponse.ok("게시글이 작성되었습니다.", response));
     }
 
-    @Operation(summary = "게시글 목록 조회")
+    @Operation(
+            summary = "게시글 목록 조회",
+            description =
+                    "게시글 목록을 커서 기반으로 조회합니다. "
+                            + "jobRole과 careerYear는 반복 쿼리 파라미터로 다중 선택을 지원하며, "
+                            + "작성자의 현재 프로필 정보(users.job_type, users.career_level)를 기준으로 필터링합니다. "
+                            + "같은 필터 그룹 안에서는 OR 조건, 직군과 경력 조건 사이에서는 AND 조건으로 조합합니다. "
+                            + "전체 선택 상태는 해당 파라미터를 생략합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -195,8 +204,28 @@ public class PostController {
     @GetMapping
     public ApiResponse<PostListResponse> getPosts(
             @Parameter(description = "커서 (마지막 postId)") @RequestParam(required = false) Long cursor,
-            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
-        return ApiResponse.ok("게시글 목록을 조회했습니다.", postService.getPosts(cursor, size));
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size,
+            @Parameter(
+                            description =
+                                    "직군 필터. 반복 파라미터로 다중 선택 가능. "
+                                            + "예: jobRole=PLANNING&jobRole=DESIGN. "
+                                            + "허용 값: PLANNING(기획), DESIGN(디자인), DEVELOPMENT(개발), "
+                                            + "MARKETING(마케팅), SALES(영업), HR(인사), "
+                                            + "GENERAL_AFFAIRS(총무), PRODUCTION(생산), ACCOUNTING(회계), OTHER(기타)")
+                    @RequestParam(required = false)
+                    List<String> jobRole,
+            @Parameter(
+                            description =
+                                    "경력 필터. 반복 파라미터로 다중 선택 가능. "
+                                            + "예: careerYear=YEAR_1&careerYear=YEAR_3. "
+                                            + "허용 값: NEWCOMER(신입), YEAR_1(1년차), YEAR_2(2년차), "
+                                            + "YEAR_3(3년차), YEAR_4(4년차), YEAR_5(5년차), "
+                                            + "YEAR_6(6년차), YEAR_7_PLUS(7년차 이상)")
+                    @RequestParam(required = false)
+                    List<String> careerYear) {
+        return ApiResponse.ok(
+                "게시글 목록을 조회했습니다.",
+                postService.getPosts(cursor, size, new PostSearchCondition(jobRole, careerYear)));
     }
 
     @Operation(summary = "게시글 상세 조회")

--- a/src/main/java/com/ddd/webbb/user/application/UserService.java
+++ b/src/main/java/com/ddd/webbb/user/application/UserService.java
@@ -59,7 +59,10 @@ public class UserService {
                 userRepository
                         .findByPublicIdAndDeletedAtIsNull(publicId)
                         .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
-        user.update(request.nickname(), request.jobType(), request.careerLevel());
+        user.update(
+                request.nickname(),
+                request.jobType() != null ? request.jobType().name() : null,
+                request.careerLevel() != null ? request.careerLevel().name() : null);
         return UserResponse.from(user);
     }
 

--- a/src/main/java/com/ddd/webbb/user/domain/CareerLevel.java
+++ b/src/main/java/com/ddd/webbb/user/domain/CareerLevel.java
@@ -1,0 +1,22 @@
+package com.ddd.webbb.user.domain;
+
+public enum CareerLevel {
+    NEWCOMER("신입"),
+    YEAR_1("1년차"),
+    YEAR_2("2년차"),
+    YEAR_3("3년차"),
+    YEAR_4("4년차"),
+    YEAR_5("5년차"),
+    YEAR_6("6년차"),
+    YEAR_7_PLUS("7년차 이상");
+
+    private final String displayName;
+
+    CareerLevel(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/ddd/webbb/user/domain/JobType.java
+++ b/src/main/java/com/ddd/webbb/user/domain/JobType.java
@@ -1,0 +1,24 @@
+package com.ddd.webbb.user.domain;
+
+public enum JobType {
+    PLANNING("기획"),
+    DESIGN("디자인"),
+    DEVELOPMENT("개발"),
+    MARKETING("마케팅"),
+    SALES("영업"),
+    HR("인사"),
+    GENERAL_AFFAIRS("총무"),
+    PRODUCTION("생산"),
+    ACCOUNTING("회계"),
+    OTHER("기타");
+
+    private final String displayName;
+
+    JobType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/ddd/webbb/user/interfaces/UserController.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/UserController.java
@@ -117,8 +117,8 @@ public class UserController {
                             "id": 1,
                             "email": "test@test.com",
                             "nickname": "ogu",
-                            "jobType": "BACKEND",
-                            "careerLevel": "3년차",
+                            "jobType": "DEVELOPMENT",
+                            "careerLevel": "YEAR_3",
                             "isActive": true,
                             "createdAt": "2026-05-03T12:00:00"
                           },
@@ -183,7 +183,17 @@ public class UserController {
         return ApiResponse.ok(userService.getUsers(cursor, size));
     }
 
-    @Operation(summary = "회원 정보 수정")
+    @Operation(
+            summary = "회원 정보 수정",
+            description =
+                    "회원 닉네임, 직군(jobType), 경력(careerLevel)을 수정합니다. "
+                            + "직군/경력은 게시글 목록 필터링 기준으로 사용되므로 아래 코드값만 입력할 수 있습니다.\n\n"
+                            + "직군 허용 값: PLANNING(기획), DESIGN(디자인), DEVELOPMENT(개발), MARKETING(마케팅), "
+                            + "SALES(영업), HR(인사), GENERAL_AFFAIRS(총무), PRODUCTION(생산), "
+                            + "ACCOUNTING(회계), OTHER(기타)\n"
+                            + "경력 허용 값: NEWCOMER(신입), YEAR_1(1년차), YEAR_2(2년차), YEAR_3(3년차), "
+                            + "YEAR_4(4년차), YEAR_5(5년차), YEAR_6(6년차), YEAR_7_PLUS(7년차 이상)\n\n"
+                            + "허용 값 외 문자열을 보내면 400 Bad Request를 반환합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -201,8 +211,8 @@ public class UserController {
                             "id": 1,
                             "email": "test@test.com",
                             "nickname": "newname",
-                            "jobType": "BACKEND",
-                            "careerLevel": "3년차",
+                            "jobType": "DEVELOPMENT",
+                            "careerLevel": "YEAR_3",
                             "isActive": true,
                             "createdAt": "2026-05-03T12:00:00"
                           },
@@ -276,8 +286,8 @@ public class UserController {
                             "id": "550e8400-e29b-41d4-a716-446655440000",
                             "email": "test@test.com",
                             "nickname": "ogu",
-                            "jobType": "BACKEND",
-                            "careerLevel": "3년차",
+                            "jobType": "DEVELOPMENT",
+                            "careerLevel": "YEAR_3",
                             "isActive": true,
                             "createdAt": "2026-05-03T12:00:00"
                           },
@@ -308,13 +318,23 @@ public class UserController {
                         UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
                         "test@test.com",
                         "ogu",
-                        "BACKEND",
-                        "3년차",
+                        "DEVELOPMENT",
+                        "YEAR_3",
                         true,
                         LocalDateTime.of(2026, 5, 3, 12, 0)));
     }
 
-    @Operation(summary = "내 프로필 수정")
+    @Operation(
+            summary = "내 프로필 수정",
+            description =
+                    "내 닉네임, 직군(jobType), 경력(careerLevel)을 수정합니다. "
+                            + "직군/경력은 게시글 목록 필터링 기준으로 사용되므로 아래 코드값만 입력할 수 있습니다.\n\n"
+                            + "직군 허용 값: PLANNING(기획), DESIGN(디자인), DEVELOPMENT(개발), MARKETING(마케팅), "
+                            + "SALES(영업), HR(인사), GENERAL_AFFAIRS(총무), PRODUCTION(생산), "
+                            + "ACCOUNTING(회계), OTHER(기타)\n"
+                            + "경력 허용 값: NEWCOMER(신입), YEAR_1(1년차), YEAR_2(2년차), YEAR_3(3년차), "
+                            + "YEAR_4(4년차), YEAR_5(5년차), YEAR_6(6년차), YEAR_7_PLUS(7년차 이상)\n\n"
+                            + "허용 값 외 문자열을 보내면 400 Bad Request를 반환합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -333,7 +353,7 @@ public class UserController {
                             "email": "test@test.com",
                             "nickname": "newogu",
                             "jobType": "PLANNING",
-                            "careerLevel": "5년차",
+                            "careerLevel": "YEAR_5",
                             "isActive": true,
                             "createdAt": "2026-05-03T12:00:00"
                           },
@@ -365,8 +385,8 @@ public class UserController {
                         UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
                         "test@test.com",
                         request.nickname() != null ? request.nickname() : "ogu",
-                        request.jobType() != null ? request.jobType() : "BACKEND",
-                        request.careerLevel() != null ? request.careerLevel() : "3년차",
+                        request.jobType() != null ? request.jobType().name() : "DEVELOPMENT",
+                        request.careerLevel() != null ? request.careerLevel().name() : "YEAR_3",
                         true,
                         LocalDateTime.of(2026, 5, 3, 12, 0)));
     }

--- a/src/main/java/com/ddd/webbb/user/interfaces/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/dto/UserProfileUpdateRequest.java
@@ -1,10 +1,45 @@
 package com.ddd.webbb.user.interfaces.dto;
 
+import com.ddd.webbb.user.domain.CareerLevel;
+import com.ddd.webbb.user.domain.JobType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
 public record UserProfileUpdateRequest(
         @Schema(example = "newogu") @Size(min = 1, max = 10, message = "닉네임은 1자 이상 10자 이하여야 합니다.")
                 String nickname,
-        @Schema(example = "PLANNING") String jobType,
-        @Schema(example = "3년차") String careerLevel) {}
+        @Schema(
+                        description =
+                                "직군. PLANNING=기획, DESIGN=디자인, DEVELOPMENT=개발, MARKETING=마케팅, "
+                                        + "SALES=영업, HR=인사, GENERAL_AFFAIRS=총무, PRODUCTION=생산, "
+                                        + "ACCOUNTING=회계, OTHER=기타",
+                        example = "PLANNING",
+                        allowableValues = {
+                            "PLANNING",
+                            "DESIGN",
+                            "DEVELOPMENT",
+                            "MARKETING",
+                            "SALES",
+                            "HR",
+                            "GENERAL_AFFAIRS",
+                            "PRODUCTION",
+                            "ACCOUNTING",
+                            "OTHER"
+                        })
+                JobType jobType,
+        @Schema(
+                        description =
+                                "경력. NEWCOMER=신입, YEAR_1=1년차, YEAR_2=2년차, YEAR_3=3년차, "
+                                        + "YEAR_4=4년차, YEAR_5=5년차, YEAR_6=6년차, YEAR_7_PLUS=7년차 이상",
+                        example = "YEAR_3",
+                        allowableValues = {
+                            "NEWCOMER",
+                            "YEAR_1",
+                            "YEAR_2",
+                            "YEAR_3",
+                            "YEAR_4",
+                            "YEAR_5",
+                            "YEAR_6",
+                            "YEAR_7_PLUS"
+                        })
+                CareerLevel careerLevel) {}

--- a/src/main/java/com/ddd/webbb/user/interfaces/dto/UserUpdateRequest.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/dto/UserUpdateRequest.java
@@ -1,10 +1,45 @@
 package com.ddd.webbb.user.interfaces.dto;
 
+import com.ddd.webbb.user.domain.CareerLevel;
+import com.ddd.webbb.user.domain.JobType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
 public record UserUpdateRequest(
         @Schema(example = "newname") @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
                 String nickname,
-        @Schema(example = "BACKEND") String jobType,
-        @Schema(example = "3년차") String careerLevel) {}
+        @Schema(
+                        description =
+                                "직군. PLANNING=기획, DESIGN=디자인, DEVELOPMENT=개발, MARKETING=마케팅, "
+                                        + "SALES=영업, HR=인사, GENERAL_AFFAIRS=총무, PRODUCTION=생산, "
+                                        + "ACCOUNTING=회계, OTHER=기타",
+                        example = "DEVELOPMENT",
+                        allowableValues = {
+                            "PLANNING",
+                            "DESIGN",
+                            "DEVELOPMENT",
+                            "MARKETING",
+                            "SALES",
+                            "HR",
+                            "GENERAL_AFFAIRS",
+                            "PRODUCTION",
+                            "ACCOUNTING",
+                            "OTHER"
+                        })
+                JobType jobType,
+        @Schema(
+                        description =
+                                "경력. NEWCOMER=신입, YEAR_1=1년차, YEAR_2=2년차, YEAR_3=3년차, "
+                                        + "YEAR_4=4년차, YEAR_5=5년차, YEAR_6=6년차, YEAR_7_PLUS=7년차 이상",
+                        example = "YEAR_3",
+                        allowableValues = {
+                            "NEWCOMER",
+                            "YEAR_1",
+                            "YEAR_2",
+                            "YEAR_3",
+                            "YEAR_4",
+                            "YEAR_5",
+                            "YEAR_6",
+                            "YEAR_7_PLUS"
+                        })
+                CareerLevel careerLevel) {}

--- a/src/test/java/com/ddd/webbb/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/ddd/webbb/auth/application/AuthServiceTest.java
@@ -15,6 +15,8 @@ import com.ddd.webbb.config.TestRedisConfig;
 import com.ddd.webbb.global.auth.JwtProvider;
 import com.ddd.webbb.global.common.exception.AppException;
 import com.ddd.webbb.global.common.exception.ErrorCode;
+import com.ddd.webbb.user.domain.CareerLevel;
+import com.ddd.webbb.user.domain.JobType;
 import com.ddd.webbb.user.domain.User;
 import com.ddd.webbb.user.domain.UserRepository;
 import java.util.UUID;
@@ -47,7 +49,11 @@ class AuthServiceTest {
             // Given
             EmailSignupRequest request =
                     new EmailSignupRequest(
-                            "new@test.com", "password123!", "테스터", "DEVELOPMENT", "NEWCOMER");
+                            "new@test.com",
+                            "password123!",
+                            "테스터",
+                            JobType.DEVELOPMENT,
+                            CareerLevel.NEWCOMER);
 
             // When
             AuthResponse response = authService.signupEmail(request);
@@ -61,6 +67,11 @@ class AuthServiceTest {
             assertThat(response.tokens().accessToken()).isNotBlank();
             assertThat(response.tokens().refreshToken()).isNotBlank();
             assertThat(userRepository.existsByEmailAndDeletedAtIsNull("new@test.com")).isTrue();
+
+            User savedUser =
+                    userRepository.findByEmailAndDeletedAtIsNull("new@test.com").orElseThrow();
+            assertThat(savedUser.getJobType()).isEqualTo("DEVELOPMENT");
+            assertThat(savedUser.getCareerLevel()).isEqualTo("NEWCOMER");
         }
 
         @Test

--- a/src/test/java/com/ddd/webbb/auth/interfaces/AuthControllerTest.java
+++ b/src/test/java/com/ddd/webbb/auth/interfaces/AuthControllerTest.java
@@ -93,6 +93,50 @@ class AuthControllerTest {
                     """))
                     .andExpect(status().isBadRequest());
         }
+
+        @Test
+        @DisplayName("허용되지 않은 직군/경력 코드 → 400")
+        void invalidJobRoleAndCareerYear() throws Exception {
+            mockMvc.perform(
+                            post("/api/auth/signup/email")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                    {
+                        "email": "invalid-profile@test.com",
+                        "password": "password123!",
+                        "nickname": "잘못된프로필",
+                        "jobRole": "BACKEND",
+                        "careerYear": "3년차"
+                    }
+                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("유효하지 않은 요청입니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/auth/oauth/{provider}")
+    class OAuthLogin {
+
+        @Test
+        @DisplayName("허용되지 않은 직군/경력 코드 → 400")
+        void invalidJobRoleAndCareerYear() throws Exception {
+            mockMvc.perform(
+                            post("/api/auth/oauth/google")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                    {
+                        "oauthAccessToken": "provider-access-token",
+                        "nickname": "소셜유저",
+                        "jobRole": "BACKEND",
+                        "careerYear": "3년차"
+                    }
+                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("유효하지 않은 요청입니다."));
+        }
     }
 
     @Nested

--- a/src/test/java/com/ddd/webbb/post/application/PostServiceTest.java
+++ b/src/test/java/com/ddd/webbb/post/application/PostServiceTest.java
@@ -28,9 +28,11 @@ import com.ddd.webbb.post.interfaces.dto.PostCreateResponse;
 import com.ddd.webbb.user.application.UserService;
 import com.ddd.webbb.user.domain.User;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class PostServiceTest {
@@ -65,6 +67,22 @@ class PostServiceTest {
                         monsterService,
                         postEmotionService,
                         commentService);
+    }
+
+    @Test
+    void 게시글_목록_조회_필터_조건을_레포지토리에_전달한다() {
+        PostSearchCondition condition =
+                new PostSearchCondition(List.of("PLANNING", "DESIGN"), List.of("YEAR_3"));
+        given(postRepositoryImpl.findByCursor(eq(null), eq(20), any(PostSearchCondition.class)))
+                .willReturn(List.of());
+
+        postService.getPosts(null, 20, condition);
+
+        ArgumentCaptor<PostSearchCondition> conditionCaptor =
+                ArgumentCaptor.forClass(PostSearchCondition.class);
+        verify(postRepositoryImpl).findByCursor(eq(null), eq(20), conditionCaptor.capture());
+        assertThat(conditionCaptor.getValue().jobRoles()).containsExactly("PLANNING", "DESIGN");
+        assertThat(conditionCaptor.getValue().careerYears()).containsExactly("YEAR_3");
     }
 
     @Test

--- a/src/test/java/com/ddd/webbb/post/infrastructure/PostRepositoryImplTest.java
+++ b/src/test/java/com/ddd/webbb/post/infrastructure/PostRepositoryImplTest.java
@@ -1,0 +1,101 @@
+package com.ddd.webbb.post.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddd.webbb.category.domain.BoardCategory;
+import com.ddd.webbb.global.config.JpaConfig;
+import com.ddd.webbb.post.application.PostSearchCondition;
+import com.ddd.webbb.post.domain.CommentTone;
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.user.domain.User;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({JpaConfig.class, PostRepositoryImpl.class})
+@ActiveProfiles("test")
+class PostRepositoryImplTest {
+
+    @Autowired private jakarta.persistence.EntityManager entityManager;
+    @Autowired private PostRepositoryImpl postRepositoryImpl;
+
+    @Test
+    void 직군과_경력_필터를_조합해_게시글을_조회한다() {
+        BoardCategory category = persistCategory();
+        Post planningYear3 =
+                persistPost("planning3@test.com", "기획3", "PLANNING", "YEAR_3", category);
+        Post designYear3 = persistPost("design3@test.com", "디자인3", "DESIGN", "YEAR_3", category);
+        persistPost("developmentYear3@test.com", "개발3", "DEVELOPMENT", "YEAR_3", category);
+        persistPost("planningYear1@test.com", "기획1", "PLANNING", "YEAR_1", category);
+        flushAndClear();
+
+        List<Post> posts =
+                postRepositoryImpl.findByCursor(
+                        null,
+                        10,
+                        new PostSearchCondition(List.of("PLANNING", "DESIGN"), List.of("YEAR_3")));
+
+        assertThat(posts)
+                .extracting(Post::getId)
+                .containsExactly(designYear3.getId(), planningYear3.getId());
+    }
+
+    @Test
+    void 커서는_필터링된_결과_안에서_적용된다() {
+        BoardCategory category = persistCategory();
+        Post first = persistPost("first@test.com", "첫번째", "PLANNING", "YEAR_3", category);
+        Post second = persistPost("second@test.com", "두번째", "PLANNING", "YEAR_3", category);
+        persistPost("third@test.com", "세번째", "DESIGN", "YEAR_3", category);
+        flushAndClear();
+
+        List<Post> posts =
+                postRepositoryImpl.findByCursor(
+                        second.getId(),
+                        10,
+                        new PostSearchCondition(List.of("PLANNING"), List.of()));
+
+        assertThat(posts).extracting(Post::getId).containsExactly(first.getId());
+    }
+
+    @Test
+    void 필터가_없으면_삭제되지_않은_게시글을_최신순으로_조회한다() {
+        BoardCategory category = persistCategory();
+        Post first = persistPost("all1@test.com", "전체1", "PLANNING", "YEAR_1", category);
+        Post second = persistPost("all2@test.com", "전체2", "DESIGN", "YEAR_3", category);
+        flushAndClear();
+
+        List<Post> posts = postRepositoryImpl.findByCursor(null, 10, PostSearchCondition.empty());
+
+        assertThat(posts).extracting(Post::getId).containsExactly(second.getId(), first.getId());
+    }
+
+    private BoardCategory persistCategory() {
+        BoardCategory category = BoardCategory.create("멘탈케어", "기본 카테고리", 0);
+        entityManager.persist(category);
+        return category;
+    }
+
+    private Post persistPost(
+            String email,
+            String nickname,
+            String jobType,
+            String careerLevel,
+            BoardCategory category) {
+        User user = User.createOAuthUser(email, nickname, jobType, careerLevel);
+        entityManager.persist(user);
+        Post post =
+                Post.create(
+                        user, category, nickname + " 제목", nickname + " 내용", CommentTone.COMFORT_ME);
+        entityManager.persist(post);
+        return post;
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/com/ddd/webbb/post/interfaces/PostControllerTest.java
+++ b/src/test/java/com/ddd/webbb/post/interfaces/PostControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -23,16 +24,19 @@ import com.ddd.webbb.global.common.exception.AppException;
 import com.ddd.webbb.global.common.exception.ErrorCode;
 import com.ddd.webbb.global.config.SecurityConfig;
 import com.ddd.webbb.global.security.CustomUserPrincipal;
+import com.ddd.webbb.post.application.PostSearchCondition;
 import com.ddd.webbb.post.application.PostService;
 import com.ddd.webbb.post.domain.CommentTone;
 import com.ddd.webbb.post.interfaces.dto.PostCreateRequest;
 import com.ddd.webbb.post.interfaces.dto.PostCreateResponse;
+import com.ddd.webbb.post.interfaces.dto.PostListResponse;
 import com.ddd.webbb.user.application.UserService;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -56,6 +60,31 @@ class PostControllerTest {
     @MockitoBean private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     @MockitoBean private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     @MockitoBean private RedisOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+    @Test
+    void 게시글_목록_조회는_직군과_경력_다중_필터를_서비스에_전달한다() throws Exception {
+        given(postService.getPosts(eq(null), eq(20), any(PostSearchCondition.class)))
+                .willReturn(new PostListResponse(List.of(), null));
+
+        mockMvc.perform(
+                        get("/api/posts")
+                                .param("jobRole", "PLANNING", "DESIGN")
+                                .param("careerYear", "YEAR_3")
+                                .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("게시글 목록을 조회했습니다."));
+
+        ArgumentCaptor<PostSearchCondition> conditionCaptor =
+                ArgumentCaptor.forClass(PostSearchCondition.class);
+        verify(postService).getPosts(eq(null), eq(20), conditionCaptor.capture());
+
+        PostSearchCondition condition = conditionCaptor.getValue();
+        org.assertj.core.api.Assertions.assertThat(condition.jobRoles())
+                .containsExactly("PLANNING", "DESIGN");
+        org.assertj.core.api.Assertions.assertThat(condition.careerYears())
+                .containsExactly("YEAR_3");
+    }
 
     @Test
     void 정상_글_작성은_201을_반환한다() throws Exception {

--- a/src/test/java/com/ddd/webbb/user/application/UserServiceTest.java
+++ b/src/test/java/com/ddd/webbb/user/application/UserServiceTest.java
@@ -1,0 +1,67 @@
+package com.ddd.webbb.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.ddd.webbb.user.domain.CareerLevel;
+import com.ddd.webbb.user.domain.JobType;
+import com.ddd.webbb.user.domain.User;
+import com.ddd.webbb.user.domain.UserRepository;
+import com.ddd.webbb.user.infrastructure.UserRepositoryImpl;
+import com.ddd.webbb.user.interfaces.dto.UserResponse;
+import com.ddd.webbb.user.interfaces.dto.UserUpdateRequest;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class UserServiceTest {
+
+    private UserRepository userRepository;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        UserRepositoryImpl userRepositoryImpl = mock(UserRepositoryImpl.class);
+        userService = new UserService(userRepository, userRepositoryImpl);
+    }
+
+    @Test
+    void 회원정보수정은_직군과_경력_enum을_코드값으로_저장한다() {
+        UUID userId = UUID.randomUUID();
+        User user = User.createOAuthUser("ogu@test.com", "ogu", "DESIGN", "YEAR_1");
+        ReflectionTestUtils.setField(user, "publicId", userId);
+        given(userRepository.findByPublicIdAndDeletedAtIsNull(userId))
+                .willReturn(Optional.of(user));
+
+        UserResponse response =
+                userService.updateUser(
+                        userId,
+                        new UserUpdateRequest("newogu", JobType.DEVELOPMENT, CareerLevel.YEAR_3));
+
+        assertThat(response.jobType()).isEqualTo("DEVELOPMENT");
+        assertThat(response.careerLevel()).isEqualTo("YEAR_3");
+        assertThat(user.getJobType()).isEqualTo("DEVELOPMENT");
+        assertThat(user.getCareerLevel()).isEqualTo("YEAR_3");
+    }
+
+    @Test
+    void 회원정보수정에서_직군과_경력이_null이면_기존값을_유지한다() {
+        UUID userId = UUID.randomUUID();
+        User user = User.createOAuthUser("ogu@test.com", "ogu", "PLANNING", "YEAR_5");
+        ReflectionTestUtils.setField(user, "publicId", userId);
+        given(userRepository.findByPublicIdAndDeletedAtIsNull(userId))
+                .willReturn(Optional.of(user));
+
+        UserResponse response =
+                userService.updateUser(userId, new UserUpdateRequest("newogu", null, null));
+
+        assertThat(response.jobType()).isEqualTo("PLANNING");
+        assertThat(response.careerLevel()).isEqualTo("YEAR_5");
+        assertThat(user.getJobType()).isEqualTo("PLANNING");
+        assertThat(user.getCareerLevel()).isEqualTo("YEAR_5");
+    }
+}

--- a/src/test/java/com/ddd/webbb/user/interfaces/UserControllerTest.java
+++ b/src/test/java/com/ddd/webbb/user/interfaces/UserControllerTest.java
@@ -1,0 +1,91 @@
+package com.ddd.webbb.user.interfaces;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ddd.webbb.global.auth.CustomOAuth2UserService;
+import com.ddd.webbb.global.auth.JwtAuthFilter;
+import com.ddd.webbb.global.auth.JwtAuthenticationEntryPoint;
+import com.ddd.webbb.global.auth.JwtProvider;
+import com.ddd.webbb.global.auth.OAuth2LoginFailureHandler;
+import com.ddd.webbb.global.auth.OAuth2LoginSuccessHandler;
+import com.ddd.webbb.global.auth.RedisOAuth2AuthorizationRequestRepository;
+import com.ddd.webbb.global.config.SecurityConfig;
+import com.ddd.webbb.global.security.CustomUserPrincipal;
+import com.ddd.webbb.user.application.UserService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class, JwtAuthenticationEntryPoint.class})
+@ActiveProfiles("test")
+class UserControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private UserService userService;
+    @MockitoBean private JwtProvider jwtProvider;
+    @MockitoBean private CustomOAuth2UserService customOAuth2UserService;
+    @MockitoBean private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    @MockitoBean private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    @MockitoBean private RedisOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+    @Test
+    void 회원정보수정은_허용되지_않은_직군과_경력_코드를_거부한다() throws Exception {
+        UUID userId = UUID.randomUUID();
+        CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "ogu");
+
+        mockMvc.perform(
+                        patch("/api/users/{id}", userId)
+                                .with(
+                                        authentication(
+                                                new UsernamePasswordAuthenticationToken(
+                                                        principal, null, List.of())))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                    {
+                      "nickname": "ogu",
+                      "jobType": "BACKEND",
+                      "careerLevel": "3년차"
+                    }
+                    """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("유효하지 않은 요청입니다."));
+    }
+
+    @Test
+    void 내프로필수정은_허용되지_않은_직군과_경력_코드를_거부한다() throws Exception {
+        UUID userId = UUID.randomUUID();
+        CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "ogu");
+
+        mockMvc.perform(
+                        patch("/api/users/me/profile")
+                                .with(
+                                        authentication(
+                                                new UsernamePasswordAuthenticationToken(
+                                                        principal, null, List.of())))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                    {
+                      "nickname": "ogu",
+                      "jobType": "BACKEND",
+                      "careerLevel": "5년차"
+                    }
+                    """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("유효하지 않은 요청입니다."));
+    }
+}


### PR DESCRIPTION
## PR 제목(내용 요약)
feat: 게시글 목록 직군·경력 필터링 및 회원 프로필 값 검증

## 📌 변경 내용 & 이유

게시글 목록에서 작성자의 직군과 경력 기준으로 필터링할 수 있도록 `GET /api/posts`를 확장했습니다.
필터 기준은 회원 프로필의 `job_type`, `career_level` 값이므로, 가입/수정 API에서도 같은 코드값만 저장되도록 입력값 검증을 추가했습니다.

**변경 내용**
- 게시글 목록 조회에 `jobRole`, `careerYear` 다중 쿼리 파라미터 추가
- QueryDSL 목록 조회에서 작성자 조인 후 직군/경력 조건 적용
- `JobType`, `CareerLevel` enum 추가
- 이메일 회원가입, OAuth 로그인/가입, 회원 정보 수정, 내 프로필 수정 요청 DTO에서 직군/경력 enum 검증 적용
- 허용되지 않은 직군/경력 값 입력 시 `400 Bad Request` 반환
- Swagger 문서에 직군/경력 허용값, 예시, 필터링 기준 설명 추가

## 📸 스크린샷 (선택)
> UI 변경 없음

## 🧪 테스트 방법 (선택)

```bash
./gradlew spotlessCheck
./gradlew test
```

추가/보강 테스트:
- `PostControllerTest` — 목록 조회 필터 파라미터 전달 검증
- `PostServiceTest` — 필터 조건 repository 전달 검증
- `PostRepositoryImplTest` — 직군/경력 다중 필터, cursor 조합 검증
- `AuthControllerTest` — 비표준 직군/경력 코드 400 응답 검증
- `AuthServiceTest` — 가입 시 enum 코드값 저장 검증
- `UserControllerTest` — 회원 수정 API 비표준 코드 400 응답 검증
- `UserServiceTest` — 회원 수정 시 enum 코드값 저장 및 null 기존값 유지 검증

## 📢 논의하고 싶은 내용

- 기존 DB에 이미 `BACKEND`, `3년차` 같은 비표준 값이 저장되어 있다면 별도 데이터 보정이 필요할 수 있습니다.
- 이번 PR은 DB 스키마 변경 없이 API 경계에서 입력값을 제한합니다.

## ✅ 체크리스트
- [x] 엔티티(`@Entity`) 스키마를 변경한 경우 `db/migration/V{N}__*.sql` 파일을 함께 포함했다 (해당 없음)

## 🧩 관련 이슈
Closes #86
