### PR TITLE
fix(auth): OAuthLoginRequest 중복 record 정의 제거

### DIFF
--- a/src/main/java/com/ddd/webbb/auth/application/AuthService.java
+++ b/src/main/java/com/ddd/webbb/auth/application/AuthService.java
@@ -61,7 +61,9 @@ public class AuthService {
         if (userRepository.existsByEmailAndDeletedAtIsNull(request.email())) {
             throw new AppException(ErrorCode.DUPLICATED_EMAIL);
         }
-        if (userRepository.existsByNicknameAndDeletedAtIsNull(request.nickname())) {
+
+        String nickname = normalizeNullable(request.nickname());
+        if (nickname != null && userRepository.existsByNicknameAndDeletedAtIsNull(nickname)) {
             throw new AppException(ErrorCode.DUPLICATED_NICKNAME);
         }
 
@@ -69,7 +71,7 @@ public class AuthService {
         User user =
                 User.createWithPassword(
                         request.email(),
-                        request.nickname(),
+                        nickname,
                         encodedPassword,
                         request.jobRole() != null ? request.jobRole().name() : null,
                         request.careerYear() != null ? request.careerYear().name() : null);
@@ -77,6 +79,10 @@ public class AuthService {
 
         AuthToken authToken = issueTokens(user.getPublicId());
         return new AuthResponse(UserInfo.from(user), TokenInfo.from(authToken), true);
+    }
+
+    public boolean isEmailAvailable(String email) {
+        return !userRepository.existsByEmailAndDeletedAtIsNull(email);
     }
 
     public AuthResponse loginEmail(EmailLoginRequest request) {
@@ -289,5 +295,12 @@ public class AuthService {
         String refreshToken = jwtProvider.createRefreshToken(publicId);
         refreshTokenStore.save(publicId, refreshToken);
         return new AuthToken(accessToken, refreshToken);
+    }
+
+    private String normalizeNullable(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
     }
 }

--- a/src/main/java/com/ddd/webbb/auth/interfaces/AuthController.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/AuthController.java
@@ -4,6 +4,7 @@ import com.ddd.webbb.auth.application.AuthService;
 import com.ddd.webbb.auth.infrastructure.OAuthCodeStore;
 import com.ddd.webbb.auth.interfaces.dto.AuthResponse;
 import com.ddd.webbb.auth.interfaces.dto.AuthResponse.TokenInfo;
+import com.ddd.webbb.auth.interfaces.dto.EmailCheckResponse;
 import com.ddd.webbb.auth.interfaces.dto.EmailLoginRequest;
 import com.ddd.webbb.auth.interfaces.dto.EmailSignupRequest;
 import com.ddd.webbb.auth.interfaces.dto.OAuthCodeExchangeRequest;
@@ -19,19 +20,25 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import java.security.Principal;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth", description = "인증 API")
+@Validated
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
@@ -154,16 +161,71 @@ public class AuthController {
                 "토큰 교환에 성공했습니다.", new TokenInfo(tokenPair.accessToken(), tokenPair.refreshToken()));
     }
 
+    @Operation(summary = "이메일 중복 확인", description = "이메일 회원가입 전 이메일 사용 가능 여부를 확인합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "중복 확인 성공 (available: true=사용 가능, false=이미 사용 중)",
+                content =
+                        @Content(
+                                examples = {
+                                    @ExampleObject(
+                                            name = "사용 가능",
+                                            value =
+                                                    """
+                        {
+                          "success": true,
+                          "message": "요청이 성공했습니다.",
+                          "data": { "available": true },
+                          "timestamp": "2026-06-12T12:00:00"
+                        }
+                        """),
+                                    @ExampleObject(
+                                            name = "사용 불가",
+                                            value =
+                                                    """
+                        {
+                          "success": true,
+                          "message": "요청이 성공했습니다.",
+                          "data": { "available": false },
+                          "timestamp": "2026-06-12T12:00:00"
+                        }
+                        """)
+                                })),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "유효성 검증 실패",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": false,
+                          "message": "유효하지 않은 요청입니다.",
+                          "errors": [
+                            { "field": "checkEmail.email", "reason": "이메일 형식이 올바르지 않습니다." }
+                          ],
+                          "timestamp": "2026-06-12T12:00:00"
+                        }
+                        """)))
+    })
+    @GetMapping("/email/check")
+    public ApiResponse<EmailCheckResponse> checkEmail(
+            @Parameter(description = "확인할 이메일")
+                    @RequestParam
+                    @NotBlank(message = "이메일은 필수입니다.")
+                    @Email(message = "이메일 형식이 올바르지 않습니다.")
+                    String email) {
+        return ApiResponse.ok(EmailCheckResponse.of(authService.isEmailAvailable(email)));
+    }
+
     @Operation(
             summary = "이메일 회원가입",
             description =
-                    "이메일 회원가입 시 직군(jobRole)과 경력(careerYear)을 함께 저장할 수 있습니다.\n\n"
-                            + "직군 허용 값: PLANNING(기획), DESIGN(디자인), DEVELOPMENT(개발), MARKETING(마케팅), "
-                            + "SALES(영업), HR(인사), GENERAL_AFFAIRS(총무), PRODUCTION(생산), "
-                            + "ACCOUNTING(회계), OTHER(기타)\n"
-                            + "경력 허용 값: NEWCOMER(신입), YEAR_1(1년차), YEAR_2(2년차), YEAR_3(3년차), "
-                            + "YEAR_4(4년차), YEAR_5(5년차), YEAR_6(6년차), YEAR_7_PLUS(7년차 이상)\n\n"
-                            + "허용 값 외 문자열을 보내면 400 Bad Request를 반환합니다.")
+                    "이메일과 비밀번호로 회원가입합니다. 닉네임, 직군(jobRole), 경력(careerYear)은 선택 입력입니다.\n\n"
+                            + "비밀번호 조건: 8자 이상 20자 이하, 영문 + 숫자 조합")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "201",
@@ -180,10 +242,10 @@ public class AuthController {
                           "data": {
                             "user": {
                               "id": "01939b10-7b0f-7c8f-9a2b-111111111111",
-                              "email": "ogu@example.com",
-                              "nickname": "ogu",
-                              "jobRole": "DEVELOPMENT",
-                              "careerYear": "NEWCOMER",
+                              "email": "5959@gmail.com",
+                              "nickname": null,
+                              "jobRole": null,
+                              "careerYear": null,
                               "status": "ACTIVE"
                             },
                             "tokens": {
@@ -224,7 +286,7 @@ public class AuthController {
                           "message": "유효하지 않은 요청입니다.",
                           "errors": [
                             { "field": "email", "reason": "must not be blank" },
-                            { "field": "password", "reason": "must not be blank" }
+                            { "field": "password", "reason": "비밀번호는 영문과 숫자를 포함해야 합니다." }
                           ],
                           "timestamp": "2026-05-21T12:00:00"
                         }
@@ -232,7 +294,23 @@ public class AuthController {
     })
     @PostMapping("/signup/email")
     public ResponseEntity<ApiResponse<AuthResponse>> signupEmail(
-            @RequestBody @Valid EmailSignupRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "이메일 회원가입 요청. nickname, jobRole, careerYear는 선택 입력입니다.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            examples =
+                                                    @ExampleObject(
+                                                            value =
+                                                                    """
+                        {
+                          "email": "5959@gmail.com",
+                          "password": "5959ohguohgu"
+                        }
+                        """)))
+                    @RequestBody
+                    @Valid
+                    EmailSignupRequest request) {
         AuthResponse response = authService.signupEmail(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.ok("회원가입에 성공했습니다.", response));

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailCheckResponse.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailCheckResponse.java
@@ -1,0 +1,8 @@
+package com.ddd.webbb.auth.interfaces.dto;
+
+public record EmailCheckResponse(boolean available) {
+
+    public static EmailCheckResponse of(boolean available) {
+        return new EmailCheckResponse(available);
+    }
+}

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailSignupRequest.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/EmailSignupRequest.java
@@ -5,27 +5,36 @@ import com.ddd.webbb.user.domain.JobType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record EmailSignupRequest(
-        @Schema(example = "test@test.com")
+        @Schema(example = "5959@gmail.com", requiredMode = Schema.RequiredMode.REQUIRED)
                 @NotBlank(message = "이메일은 필수입니다.")
                 @Email(message = "이메일 형식이 올바르지 않습니다.")
                 String email,
-        @Schema(example = "password123!")
+        @Schema(example = "5959ohguohgu", requiredMode = Schema.RequiredMode.REQUIRED)
                 @NotBlank(message = "비밀번호는 필수입니다.")
-                @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+                @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
+                @Pattern(
+                        regexp = "^(?=.*[A-Za-z])(?=.*\\d).+$",
+                        message = "비밀번호는 영문과 숫자를 포함해야 합니다.")
                 String password,
-        @Schema(example = "ogu")
-                @NotBlank(message = "닉네임은 필수입니다.")
+        @Schema(
+                        description = "선택 입력. 미전달 시 null로 저장되며, 후속 프로필 설정에서 입력할 수 있습니다.",
+                        example = "ogu",
+                        nullable = true,
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
                 @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
                 String nickname,
         @Schema(
                         description =
-                                "직군. PLANNING=기획, DESIGN=디자인, DEVELOPMENT=개발, MARKETING=마케팅, "
+                                "선택 입력. 직군. PLANNING=기획, DESIGN=디자인, DEVELOPMENT=개발, MARKETING=마케팅, "
                                         + "SALES=영업, HR=인사, GENERAL_AFFAIRS=총무, PRODUCTION=생산, "
                                         + "ACCOUNTING=회계, OTHER=기타",
                         example = "DEVELOPMENT",
+                        nullable = true,
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
                         allowableValues = {
                             "PLANNING",
                             "DESIGN",
@@ -41,9 +50,11 @@ public record EmailSignupRequest(
                 JobType jobRole,
         @Schema(
                         description =
-                                "경력. NEWCOMER=신입, YEAR_1=1년차, YEAR_2=2년차, YEAR_3=3년차, "
+                                "선택 입력. 경력. NEWCOMER=신입, YEAR_1=1년차, YEAR_2=2년차, YEAR_3=3년차, "
                                         + "YEAR_4=4년차, YEAR_5=5년차, YEAR_6=6년차, YEAR_7_PLUS=7년차 이상",
                         example = "NEWCOMER",
+                        nullable = true,
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
                         allowableValues = {
                             "NEWCOMER",
                             "YEAR_1",

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/OAuthLoginRequest.java
@@ -12,9 +12,6 @@ public record OAuthLoginRequest(
         @Schema(example = "ogu", description = "닉네임 (최대 10자)")
                 @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
                 String nickname,
-        @Schema(example = "DEVELOPMENT") String jobRole,
-        @Schema(example = "YEAR_3") String careerYear) {}
-        @Schema(example = "ogu") String nickname,
         @Schema(
                         description =
                                 "직군. PLANNING=기획, DESIGN=디자인, DEVELOPMENT=개발, MARKETING=마케팅, "

--- a/src/main/java/com/ddd/webbb/global/config/SecurityConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SecurityConfig.java
@@ -76,6 +76,7 @@ public class SecurityConfig {
                                         // Auth 공개 엔드포인트
                                         .requestMatchers(
                                                 "/api/auth/signup/email",
+                                                "/api/auth/email/check",
                                                 "/api/auth/login/email",
                                                 "/api/auth/oauth/**",
                                                 "/api/auth/refresh")

--- a/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
@@ -139,6 +139,7 @@ public class SwaggerConfig {
 
         put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/auth/oauth/{provider}");
         put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/auth/oauth/exchange");
+        put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/auth/email/check");
         put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/auth/signup/email");
         put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/auth/login/email");
         put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/auth/logout");

--- a/src/main/java/com/ddd/webbb/user/domain/User.java
+++ b/src/main/java/com/ddd/webbb/user/domain/User.java
@@ -27,7 +27,7 @@ public class User extends BaseEntity {
     @Column(length = 255)
     private String passwordHash;
 
-    @Column(unique = true, nullable = false, length = 50)
+    @Column(unique = true, length = 50)
     private String nickname;
 
     @Column(length = 50)

--- a/src/main/resources/db/migration/V2__allow_nullable_user_nickname.sql
+++ b/src/main/resources/db/migration/V2__allow_nullable_user_nickname.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    MODIFY nickname VARCHAR(50) NULL;

--- a/src/test/java/com/ddd/webbb/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/ddd/webbb/auth/application/AuthServiceTest.java
@@ -44,16 +44,11 @@ class AuthServiceTest {
     class SignupEmail {
 
         @Test
-        @DisplayName("정상 회원가입 → 사용자 생성 + 토큰 발급")
+        @DisplayName("닉네임 없이 정상 회원가입 → 사용자 생성 + 토큰 발급")
         void success() {
             // Given
             EmailSignupRequest request =
-                    new EmailSignupRequest(
-                            "new@test.com",
-                            "password123!",
-                            "테스터",
-                            JobType.DEVELOPMENT,
-                            CareerLevel.NEWCOMER);
+                    new EmailSignupRequest("new@test.com", "password123", null, null, null);
 
             // When
             AuthResponse response = authService.signupEmail(request);
@@ -61,17 +56,18 @@ class AuthServiceTest {
             // Then
             assertThat(response.isNewUser()).isTrue();
             assertThat(response.user().email()).isEqualTo("new@test.com");
-            assertThat(response.user().nickname()).isEqualTo("테스터");
-            assertThat(response.user().jobRole()).isEqualTo("DEVELOPMENT");
-            assertThat(response.user().careerYear()).isEqualTo("NEWCOMER");
+            assertThat(response.user().nickname()).isNull();
+            assertThat(response.user().jobRole()).isNull();
+            assertThat(response.user().careerYear()).isNull();
             assertThat(response.tokens().accessToken()).isNotBlank();
             assertThat(response.tokens().refreshToken()).isNotBlank();
             assertThat(userRepository.existsByEmailAndDeletedAtIsNull("new@test.com")).isTrue();
 
             User savedUser =
                     userRepository.findByEmailAndDeletedAtIsNull("new@test.com").orElseThrow();
-            assertThat(savedUser.getJobType()).isEqualTo("DEVELOPMENT");
-            assertThat(savedUser.getCareerLevel()).isEqualTo("NEWCOMER");
+            assertThat(savedUser.getNickname()).isNull();
+            assertThat(savedUser.getJobType()).isNull();
+            assertThat(savedUser.getCareerLevel()).isNull();
         }
 
         @Test
@@ -88,6 +84,17 @@ class AuthServiceTest {
             User user = userRepository.findByEmailAndDeletedAtIsNull("hash@test.com").orElseThrow();
             assertThat(user.getPasswordHash()).isNotEqualTo("plain123!");
             assertThat(user.getPasswordHash()).startsWith("$2a$");
+        }
+
+        @Test
+        @DisplayName("이메일 사용 가능 여부를 조회한다")
+        void emailAvailable() {
+            // Given
+            createUser("existing-check@test.com", "기존유저");
+
+            // When / Then
+            assertThat(authService.isEmailAvailable("available-check@test.com")).isTrue();
+            assertThat(authService.isEmailAvailable("existing-check@test.com")).isFalse();
         }
 
         @Test
@@ -108,20 +115,24 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("이미 존재하는 닉네임 → DUPLICATED_NICKNAME 예외")
-        void duplicatedNickname() {
+        @DisplayName("닉네임을 함께 보내면 기존처럼 저장한다")
+        void optionalNickname() {
             // Given
-            createUser("other@test.com", "중복닉네임");
             EmailSignupRequest request =
-                    new EmailSignupRequest("new@test.com", "password123!", "중복닉네임", null, null);
+                    new EmailSignupRequest(
+                            "with-nickname@test.com",
+                            "password123",
+                            "테스터",
+                            JobType.DEVELOPMENT,
+                            CareerLevel.NEWCOMER);
 
-            // When / Then
-            assertThatThrownBy(() -> authService.signupEmail(request))
-                    .isInstanceOf(AppException.class)
-                    .satisfies(
-                            e ->
-                                    assertThat(((AppException) e).getErrorCode())
-                                            .isEqualTo(ErrorCode.DUPLICATED_NICKNAME));
+            // When
+            AuthResponse response = authService.signupEmail(request);
+
+            // Then
+            assertThat(response.user().nickname()).isEqualTo("테스터");
+            assertThat(response.user().jobRole()).isEqualTo("DEVELOPMENT");
+            assertThat(response.user().careerYear()).isEqualTo("NEWCOMER");
         }
     }
 

--- a/src/test/java/com/ddd/webbb/auth/interfaces/AuthControllerTest.java
+++ b/src/test/java/com/ddd/webbb/auth/interfaces/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.ddd.webbb.auth.interfaces;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -33,7 +34,7 @@ class AuthControllerTest {
 
     @Nested
     @DisplayName("POST /api/auth/oauth/{provider}")
-    class OAuthLogin {
+    class OAuthLoginValidation {
 
         @Test
         @DisplayName("닉네임 11자 이상 → 400")
@@ -53,11 +54,43 @@ class AuthControllerTest {
     }
 
     @Nested
+    @DisplayName("GET /api/auth/email/check")
+    class EmailCheck {
+
+        @Test
+        @DisplayName("사용 가능한 이메일 → available: true")
+        void available() throws Exception {
+            mockMvc.perform(get("/api/auth/email/check").param("email", "available@test.com"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.available").value(true));
+        }
+
+        @Test
+        @DisplayName("이미 사용 중인 이메일 → available: false")
+        void alreadyTaken() throws Exception {
+            signup("taken-email@test.com", "기존유저");
+
+            mockMvc.perform(get("/api/auth/email/check").param("email", "taken-email@test.com"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.available").value(false));
+        }
+
+        @Test
+        @DisplayName("이메일 형식이 아니면 → 400")
+        void invalidEmail() throws Exception {
+            mockMvc.perform(get("/api/auth/email/check").param("email", "invalid-email"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
     @DisplayName("POST /api/auth/signup/email")
     class SignupEmail {
 
         @Test
-        @DisplayName("정상 회원가입 → 201 + 사용자/토큰 반환")
+        @DisplayName("닉네임 없이 정상 회원가입 → 201 + 사용자/토큰 반환")
         void success() throws Exception {
             mockMvc.perform(
                             post("/api/auth/signup/email")
@@ -66,16 +99,13 @@ class AuthControllerTest {
                                             """
                     {
                         "email": "new@test.com",
-                        "password": "password123!",
-                        "nickname": "테스터",
-                        "jobRole": "DEVELOPMENT",
-                        "careerYear": "NEWCOMER"
+                        "password": "password123"
                     }
                     """))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.user.email").value("new@test.com"))
-                    .andExpect(jsonPath("$.data.user.nickname").value("테스터"))
+                    .andExpect(jsonPath("$.data.user.nickname").doesNotExist())
                     .andExpect(jsonPath("$.data.tokens.accessToken").isNotEmpty())
                     .andExpect(jsonPath("$.data.tokens.refreshToken").isNotEmpty())
                     .andExpect(jsonPath("$.data.isNewUser").value(true));
@@ -111,6 +141,70 @@ class AuthControllerTest {
                                     .content(
                                             """
                     {"email": "test@test.com"}
+                    """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("비밀번호 7자 → 400")
+        void passwordTooShort() throws Exception {
+            mockMvc.perform(
+                            post("/api/auth/signup/email")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                    {
+                        "email": "short-password@test.com",
+                        "password": "abc1234"
+                    }
+                    """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("비밀번호 21자 → 400")
+        void passwordTooLong() throws Exception {
+            mockMvc.perform(
+                            post("/api/auth/signup/email")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                    {
+                        "email": "long-password@test.com",
+                        "password": "abc123456789012345678"
+                    }
+                    """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("비밀번호 숫자만 입력 → 400")
+        void passwordNumbersOnly() throws Exception {
+            mockMvc.perform(
+                            post("/api/auth/signup/email")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                    {
+                        "email": "numbers-password@test.com",
+                        "password": "12345678"
+                    }
+                    """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("비밀번호 영문만 입력 → 400")
+        void passwordLettersOnly() throws Exception {
+            mockMvc.perform(
+                            post("/api/auth/signup/email")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                    {
+                        "email": "letters-password@test.com",
+                        "password": "abcdefgh"
+                    }
                     """))
                     .andExpect(status().isBadRequest());
         }

--- a/src/test/java/com/ddd/webbb/user/interfaces/UserControllerTest.java
+++ b/src/test/java/com/ddd/webbb/user/interfaces/UserControllerTest.java
@@ -1,12 +1,17 @@
 package com.ddd.webbb.user.interfaces;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.ddd.webbb.auth.infrastructure.RefreshTokenStore;
 import com.ddd.webbb.config.TestRedisConfig;
+import com.ddd.webbb.global.security.CustomUserPrincipal;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,6 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,46 +73,7 @@ class UserControllerTest {
                         {"email": "%s", "password": "password123!", "nickname": "%s"}
                         """
                                         .formatted(email, nickname)));
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.ddd.webbb.global.auth.CustomOAuth2UserService;
-import com.ddd.webbb.global.auth.JwtAuthFilter;
-import com.ddd.webbb.global.auth.JwtAuthenticationEntryPoint;
-import com.ddd.webbb.global.auth.JwtProvider;
-import com.ddd.webbb.global.auth.OAuth2LoginFailureHandler;
-import com.ddd.webbb.global.auth.OAuth2LoginSuccessHandler;
-import com.ddd.webbb.global.auth.RedisOAuth2AuthorizationRequestRepository;
-import com.ddd.webbb.global.config.SecurityConfig;
-import com.ddd.webbb.global.security.CustomUserPrincipal;
-import com.ddd.webbb.user.application.UserService;
-import java.util.List;
-import java.util.UUID;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-
-@WebMvcTest(UserController.class)
-@Import({SecurityConfig.class, JwtAuthFilter.class, JwtAuthenticationEntryPoint.class})
-@ActiveProfiles("test")
-class UserControllerTest {
-
-    @Autowired private MockMvc mockMvc;
-
-    @MockitoBean private UserService userService;
-    @MockitoBean private JwtProvider jwtProvider;
-    @MockitoBean private CustomOAuth2UserService customOAuth2UserService;
-    @MockitoBean private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
-    @MockitoBean private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
-    @MockitoBean private RedisOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+    }
 
     @Test
     void 회원정보수정은_허용되지_않은_직군과_경력_코드를_거부한다() throws Exception {


### PR DESCRIPTION
## PR 제목(내용 요약)
OAuthLoginRequest.java 컴파일 에러 핫픽스 및 이메일 회원가입 API 스펙 수정

## 📌 변경 내용 & 이유
- #92 PR 머지 충돌 해결 과정에서 두 버전의 record 정의가 한 파일에 합쳐짐
- `String jobRole, String careerYear`(구버전) + `JobType jobRole, CareerLevel careerYear`(신버전)이 중복 존재
- 첫 번째 `}` 이후에 남은 코드가 파일 최상위 레벨에 위치하게 되어 `class, interface, enum, or record expected` 컴파일 에러 발생
- `JobType`/`CareerLevel` enum 타입 + 상세 `@Schema` 어노테이션 버전만 남기고 중복 제거
- 이메일 회원가입 화면 스펙에 맞춰 `POST /api/auth/signup/email`에서 `nickname` 필수 요구를 제거
- 임시 닉네임 자동 생성 없이 `users.nickname`을 nullable로 전환하고 Flyway 마이그레이션 추가
- 이메일 사전 중복 확인용 `GET /api/auth/email/check` API 추가
- 비밀번호 검증을 `8자 이상 20자 이하`, `영문 + 숫자 조합`으로 강화
- Swagger 요청 예시, 응답 예시, API 설명, LIVE 상태 라벨을 변경 스펙에 맞게 정리

## 🧪 테스트 방법
- `./gradlew compileJava` 통과 확인
- `./gradlew spotlessCheck` 통과 확인
- `./gradlew test` 통과 확인

## 🧩 관련 이슈
- 빌드 실패 수정 (main 브랜치 CI 에러)
- #91
