### PR TITLE
feat: 스텁 API 실구현 및 게시글 조회 응답 보강

### DIFF
--- a/src/main/java/com/ddd/webbb/comment/application/CommentService.java
+++ b/src/main/java/com/ddd/webbb/comment/application/CommentService.java
@@ -50,7 +50,7 @@ public class CommentService {
     }
 
     public List<Comment> findCommentsByPost(Long postId) {
-        return commentRepository.findByPost_IdAndIsDeletedFalseOrderByCreatedAtAsc(postId);
+        return commentQueryRepository.findByPostIdWithUser(postId);
     }
 
     public CommentListResponse getComments(Long postId, Long cursor, int size) {

--- a/src/main/java/com/ddd/webbb/comment/domain/CommentLikeRepository.java
+++ b/src/main/java/com/ddd/webbb/comment/domain/CommentLikeRepository.java
@@ -1,6 +1,7 @@
 package com.ddd.webbb.comment.domain;
 
 import com.ddd.webbb.user.domain.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     Optional<CommentLike> findByCommentAndUser(Comment comment, User user);
 
     boolean existsByCommentAndUser(Comment comment, User user);
+
+    List<CommentLike> findByComment_IdInAndUser(List<Long> commentIds, User user);
 }

--- a/src/main/java/com/ddd/webbb/comment/domain/CommentQueryRepository.java
+++ b/src/main/java/com/ddd/webbb/comment/domain/CommentQueryRepository.java
@@ -8,5 +8,7 @@ public interface CommentQueryRepository {
 
     List<Comment> findRepliesByParentIds(List<Long> parentIds);
 
+    List<Comment> findByPostIdWithUser(Long postId);
+
     List<Comment> findByUserWithCursor(User user, Long cursor, int size);
 }

--- a/src/main/java/com/ddd/webbb/comment/infrastructure/CommentRepositoryImpl.java
+++ b/src/main/java/com/ddd/webbb/comment/infrastructure/CommentRepositoryImpl.java
@@ -51,6 +51,26 @@ public class CommentRepositoryImpl implements CommentQueryRepository {
     }
 
     @Override
+    public List<Comment> findByPostIdWithUser(Long postId) {
+        QComment comment = QComment.comment;
+        QUser user = QUser.user;
+        QPost post = QPost.post;
+
+        return queryFactory
+                .selectFrom(comment)
+                .join(comment.user, user)
+                .fetchJoin()
+                .join(comment.post, post)
+                .fetchJoin()
+                .where(
+                        comment.post.id.eq(postId),
+                        comment.isDeleted.isFalse(),
+                        post.isDeleted.isFalse())
+                .orderBy(comment.createdAt.asc(), comment.id.asc())
+                .fetch();
+    }
+
+    @Override
     public List<Comment> findByUserWithCursor(User user, Long cursor, int size) {
         QComment comment = QComment.comment;
         QPost post = QPost.post;

--- a/src/main/java/com/ddd/webbb/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ddd/webbb/global/common/exception/ErrorCode.java
@@ -7,9 +7,11 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요 기록이 존재하지 않습니다."),
     COMMENT_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "공감 기록이 존재하지 않습니다."),
     MONSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 몬스터입니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    ALREADY_LIKED_POST(HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),
     ALREADY_LIKED_COMMENT(HttpStatus.CONFLICT, "이미 공감한 댓글입니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     EMAIL_ALREADY_EXISTS_LINK_REQUIRED(

--- a/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
@@ -148,8 +148,8 @@ public class SwaggerConfig {
         put(statuses, ApiImplementationStatus.LIVE, "DELETE", "/api/auth/link/{provider}");
 
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/users/nickname/check");
-        put(statuses, ApiImplementationStatus.STUB, "GET", "/api/users/me");
-        put(statuses, ApiImplementationStatus.STUB, "PATCH", "/api/users/me/profile");
+        put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/users/me");
+        put(statuses, ApiImplementationStatus.LIVE, "PATCH", "/api/users/me/profile");
 
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/posts");
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/posts/{postId}");
@@ -172,8 +172,8 @@ public class SwaggerConfig {
                 "DELETE",
                 "/api/posts/{postId}/comments/{commentId}/likes/me");
 
-        put(statuses, ApiImplementationStatus.STUB, "POST", "/api/posts/{postId}/likes");
-        put(statuses, ApiImplementationStatus.STUB, "DELETE", "/api/posts/{postId}/likes/me");
+        put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/posts/{postId}/likes");
+        put(statuses, ApiImplementationStatus.LIVE, "DELETE", "/api/posts/{postId}/likes/me");
 
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/me/posts");
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/me/comments");

--- a/src/main/java/com/ddd/webbb/post/application/PostLikeService.java
+++ b/src/main/java/com/ddd/webbb/post/application/PostLikeService.java
@@ -1,0 +1,82 @@
+package com.ddd.webbb.post.application;
+
+import com.ddd.webbb.global.common.exception.AppException;
+import com.ddd.webbb.global.common.exception.ErrorCode;
+import com.ddd.webbb.monster.application.MonsterService;
+import com.ddd.webbb.monster.domain.HpActionType;
+import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostLike;
+import com.ddd.webbb.post.domain.PostLikeRepository;
+import com.ddd.webbb.post.domain.PostRepository;
+import com.ddd.webbb.post.interfaces.dto.LikeResponse;
+import com.ddd.webbb.user.application.UserService;
+import com.ddd.webbb.user.domain.User;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class PostLikeService {
+
+    private static final int POST_LIKE_HP_DELTA = 1;
+
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final UserService userService;
+    private final MonsterService monsterService;
+
+    public PostLikeService(
+            PostLikeRepository postLikeRepository,
+            PostRepository postRepository,
+            UserService userService,
+            MonsterService monsterService) {
+        this.postLikeRepository = postLikeRepository;
+        this.postRepository = postRepository;
+        this.userService = userService;
+        this.monsterService = monsterService;
+    }
+
+    @Transactional
+    public LikeResponse addPostLike(UUID userPublicId, Long postId) {
+        User user = userService.getUserEntity(userPublicId);
+        Post post = getPost(postId);
+
+        try {
+            postLikeRepository.saveAndFlush(PostLike.create(post, user));
+        } catch (DataIntegrityViolationException e) {
+            throw new AppException(ErrorCode.ALREADY_LIKED_POST);
+        }
+        post.incrementLikeCount();
+
+        Monster monster = monsterService.getMonsterByPostId(postId);
+        monsterService.decreaseMonsterHp(
+                monster, user, post, null, HpActionType.POST_LIKE, POST_LIKE_HP_DELTA);
+
+        return LikeResponse.of(post, monster);
+    }
+
+    @Transactional
+    public LikeResponse removePostLike(UUID userPublicId, Long postId) {
+        User user = userService.getUserEntity(userPublicId);
+        Post post = getPost(postId);
+
+        PostLike postLike =
+                postLikeRepository
+                        .findByPostAndUser(post, user)
+                        .orElseThrow(() -> new AppException(ErrorCode.POST_LIKE_NOT_FOUND));
+
+        postLikeRepository.delete(postLike);
+        post.decrementLikeCount();
+        Monster monster = monsterService.getMonsterByPostId(postId);
+        return LikeResponse.of(post, monster);
+    }
+
+    private Post getPost(Long postId) {
+        return postRepository
+                .findByIdAndIsDeletedFalse(postId)
+                .orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/ddd/webbb/post/application/PostService.java
+++ b/src/main/java/com/ddd/webbb/post/application/PostService.java
@@ -7,6 +7,7 @@ import com.ddd.webbb.category.domain.BoardCategory;
 import com.ddd.webbb.category.domain.BoardCategoryRepository;
 import com.ddd.webbb.comment.application.CommentService;
 import com.ddd.webbb.comment.domain.Comment;
+import com.ddd.webbb.comment.domain.CommentLikeRepository;
 import com.ddd.webbb.emotion.application.PostEmotionService;
 import com.ddd.webbb.emotion.domain.EmotionType;
 import com.ddd.webbb.emotion.domain.PostEmotion;
@@ -15,8 +16,11 @@ import com.ddd.webbb.global.common.exception.ErrorCode;
 import com.ddd.webbb.monster.application.MonsterService;
 import com.ddd.webbb.monster.domain.Monster;
 import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostLikeRepository;
+import com.ddd.webbb.post.domain.PostOrder;
+import com.ddd.webbb.post.domain.PostQueryRepository;
 import com.ddd.webbb.post.domain.PostRepository;
-import com.ddd.webbb.post.infrastructure.PostRepositoryImpl;
+import com.ddd.webbb.post.domain.PostSearchCondition;
 import com.ddd.webbb.post.interfaces.dto.PostCreateRequest;
 import com.ddd.webbb.post.interfaces.dto.PostCreateResponse;
 import com.ddd.webbb.post.interfaces.dto.PostDetailResponse;
@@ -28,6 +32,7 @@ import com.ddd.webbb.user.application.UserService;
 import com.ddd.webbb.user.domain.User;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
@@ -41,31 +46,37 @@ public class PostService {
     private static final int CONTENT_PREVIEW_LENGTH = 50;
 
     private final PostRepository postRepository;
-    private final PostRepositoryImpl postRepositoryImpl;
+    private final PostQueryRepository postQueryRepository;
+    private final PostLikeRepository postLikeRepository;
     private final BoardCategoryRepository boardCategoryRepository;
     private final UserService userService;
     private final AiAnalysisService aiAnalysisService;
     private final MonsterService monsterService;
     private final PostEmotionService postEmotionService;
     private final CommentService commentService;
+    private final CommentLikeRepository commentLikeRepository;
 
     public PostService(
             PostRepository postRepository,
-            PostRepositoryImpl postRepositoryImpl,
+            PostQueryRepository postQueryRepository,
+            PostLikeRepository postLikeRepository,
             BoardCategoryRepository boardCategoryRepository,
             UserService userService,
             AiAnalysisService aiAnalysisService,
             MonsterService monsterService,
             PostEmotionService postEmotionService,
-            CommentService commentService) {
+            CommentService commentService,
+            CommentLikeRepository commentLikeRepository) {
         this.postRepository = postRepository;
-        this.postRepositoryImpl = postRepositoryImpl;
+        this.postQueryRepository = postQueryRepository;
+        this.postLikeRepository = postLikeRepository;
         this.boardCategoryRepository = boardCategoryRepository;
         this.userService = userService;
         this.aiAnalysisService = aiAnalysisService;
         this.monsterService = monsterService;
         this.postEmotionService = postEmotionService;
         this.commentService = commentService;
+        this.commentLikeRepository = commentLikeRepository;
     }
 
     public Post getPostEntity(Long postId) {
@@ -95,12 +106,21 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostListResponse getPosts(Long cursor, int size) {
-        return getPosts(cursor, size, PostSearchCondition.empty());
+        return getPosts(null, cursor, size, PostSearchCondition.empty());
     }
 
     @Transactional(readOnly = true)
     public PostListResponse getPosts(Long cursor, int size, PostSearchCondition condition) {
-        List<Post> fetched = postRepositoryImpl.findByCursor(cursor, size, condition);
+        return getPosts(null, cursor, size, condition);
+    }
+
+    @Transactional(readOnly = true)
+    public PostListResponse getPosts(
+            UUID userPublicId, Long cursor, int size, PostSearchCondition condition) {
+        User currentUser = getCurrentUserOrNull(userPublicId);
+        Integer cursorLikeCount = resolveCursorLikeCount(cursor, condition);
+        List<Post> fetched =
+                postQueryRepository.findByCursor(cursor, cursorLikeCount, size, condition);
         boolean hasNext = fetched.size() > size;
         List<Post> posts = hasNext ? fetched.subList(0, size) : fetched;
 
@@ -111,6 +131,7 @@ public class PostService {
         Map<Long, Monster> monsterMap =
                 monsterService.findByPostIds(postIds).stream()
                         .collect(Collectors.toMap(m -> m.getPost().getId(), m -> m));
+        Set<Long> likedPostIds = findLikedPostIds(postIds, currentUser);
 
         List<PostSummary> summaries =
                 posts.stream()
@@ -119,14 +140,19 @@ public class PostService {
                                         toPostSummary(
                                                 post,
                                                 emotionMap.get(post.getId()),
-                                                monsterMap.get(post.getId())))
+                                                monsterMap.get(post.getId()),
+                                                likedPostIds.contains(post.getId())))
                         .toList();
 
-        Long nextCursor = hasNext ? posts.get(posts.size() - 1).getId() : null;
+        Long nextCursor = hasNext && !posts.isEmpty() ? posts.get(posts.size() - 1).getId() : null;
         return new PostListResponse(summaries, nextCursor);
     }
 
     public PostDetailResponse getPostDetail(Long postId) {
+        return getPostDetail(null, postId);
+    }
+
+    public PostDetailResponse getPostDetail(UUID userPublicId, Long postId) {
         Post post =
                 postRepository
                         .findByIdAndIsDeletedFalse(postId)
@@ -136,6 +162,9 @@ public class PostService {
         PostEmotion postEmotion = postEmotionService.findByPost(postId);
         Monster monster = monsterService.findByPost(postId);
         List<Comment> comments = commentService.findCommentsByPost(postId);
+        User currentUser = getCurrentUserOrNull(userPublicId);
+        Set<Long> likedCommentIds =
+                findLikedCommentIds(comments.stream().map(Comment::getId).toList(), currentUser);
 
         EmotionType emotionType = postEmotion.getEmotionType();
         return new PostDetailResponse(
@@ -155,14 +184,20 @@ public class PostService {
                         monster.getMaxHp(),
                         monster.getStatus().name()),
                 post.getLikeCount(),
+                currentUser != null && postLikeRepository.existsByPostAndUser(post, currentUser),
                 post.getCommentCount(),
                 comments.stream()
                         .map(
                                 c ->
                                         new PostDetailResponse.CommentInfo(
                                                 c.getId(),
+                                                toPublicId(c.getUser()),
                                                 c.getUser().getNickname(),
+                                                c.getUser().getJobType(),
+                                                c.getUser().getCareerLevel(),
                                                 c.getContent(),
+                                                c.getLikeCount(),
+                                                likedCommentIds.contains(c.getId()),
                                                 c.getCreatedAt()))
                         .toList(),
                 post.getCreatedAt());
@@ -209,7 +244,8 @@ public class PostService {
         post.delete();
     }
 
-    private PostSummary toPostSummary(Post post, PostEmotion postEmotion, Monster monster) {
+    private PostSummary toPostSummary(
+            Post post, PostEmotion postEmotion, Monster monster, boolean likedByMe) {
         EmotionType emotionType = postEmotion != null ? postEmotion.getEmotionType() : null;
         String emotionTypeName = emotionType != null ? emotionType.name() : null;
         MonsterInfo monsterInfo =
@@ -233,8 +269,45 @@ public class PostService {
                 emotionTypeName,
                 monsterInfo,
                 post.getLikeCount(),
+                likedByMe,
                 post.getCommentCount(),
                 post.getCreatedAt());
+    }
+
+    private User getCurrentUserOrNull(UUID userPublicId) {
+        return userPublicId == null ? null : userService.getUserEntity(userPublicId);
+    }
+
+    private Integer resolveCursorLikeCount(Long cursor, PostSearchCondition condition) {
+        if (cursor == null || condition.order() != PostOrder.POPULAR) {
+            return null;
+        }
+        return getPostEntity(cursor).getLikeCount();
+    }
+
+    private Set<Long> findLikedPostIds(List<Long> postIds, User user) {
+        if (user == null || postIds.isEmpty()) {
+            return Set.of();
+        }
+
+        return postLikeRepository.findByPost_IdInAndUser(postIds, user).stream()
+                .map(postLike -> postLike.getPost().getId())
+                .collect(Collectors.toSet());
+    }
+
+    private Set<Long> findLikedCommentIds(List<Long> commentIds, User user) {
+        if (user == null || commentIds.isEmpty()) {
+            return Set.of();
+        }
+
+        return commentLikeRepository.findByComment_IdInAndUser(commentIds, user).stream()
+                .map(commentLike -> commentLike.getComment().getId())
+                .collect(Collectors.toSet());
+    }
+
+    private String toPublicId(User user) {
+        UUID publicId = user.getPublicId();
+        return publicId != null ? publicId.toString() : null;
     }
 
     private BoardCategory resolveDefaultCategory() {

--- a/src/main/java/com/ddd/webbb/post/domain/PostLikeRepository.java
+++ b/src/main/java/com/ddd/webbb/post/domain/PostLikeRepository.java
@@ -1,0 +1,14 @@
+package com.ddd.webbb.post.domain;
+
+import com.ddd.webbb.user.domain.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Optional<PostLike> findByPostAndUser(Post post, User user);
+
+    boolean existsByPostAndUser(Post post, User user);
+
+    List<PostLike> findByPost_IdInAndUser(List<Long> postIds, User user);
+}

--- a/src/main/java/com/ddd/webbb/post/domain/PostOrder.java
+++ b/src/main/java/com/ddd/webbb/post/domain/PostOrder.java
@@ -1,0 +1,22 @@
+package com.ddd.webbb.post.domain;
+
+import com.ddd.webbb.global.common.exception.AppException;
+import com.ddd.webbb.global.common.exception.ErrorCode;
+import java.util.Locale;
+
+public enum PostOrder {
+    LATEST,
+    POPULAR;
+
+    public static PostOrder from(String value) {
+        if (value == null || value.isBlank()) {
+            return LATEST;
+        }
+
+        try {
+            return PostOrder.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new AppException(ErrorCode.INVALID_INPUT);
+        }
+    }
+}

--- a/src/main/java/com/ddd/webbb/post/domain/PostQueryRepository.java
+++ b/src/main/java/com/ddd/webbb/post/domain/PostQueryRepository.java
@@ -4,5 +4,10 @@ import com.ddd.webbb.user.domain.User;
 import java.util.List;
 
 public interface PostQueryRepository {
+    List<Post> findByCursor(Long cursor, int size, PostSearchCondition condition);
+
+    List<Post> findByCursor(
+            Long cursor, Integer cursorLikeCount, int size, PostSearchCondition condition);
+
     List<Post> findByUserWithCursor(User user, Long cursor, int size);
 }

--- a/src/main/java/com/ddd/webbb/post/domain/PostSearchCondition.java
+++ b/src/main/java/com/ddd/webbb/post/domain/PostSearchCondition.java
@@ -1,16 +1,18 @@
-package com.ddd.webbb.post.application;
+package com.ddd.webbb.post.domain;
 
 import java.util.List;
 
-public record PostSearchCondition(List<String> jobRoles, List<String> careerYears) {
+public record PostSearchCondition(
+        List<String> jobRoles, List<String> careerYears, PostOrder order) {
 
     public PostSearchCondition {
         jobRoles = normalize(jobRoles);
         careerYears = normalize(careerYears);
+        order = order == null ? PostOrder.LATEST : order;
     }
 
     public static PostSearchCondition empty() {
-        return new PostSearchCondition(List.of(), List.of());
+        return new PostSearchCondition(List.of(), List.of(), PostOrder.LATEST);
     }
 
     private static List<String> normalize(List<String> values) {

--- a/src/main/java/com/ddd/webbb/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/com/ddd/webbb/post/infrastructure/PostRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.ddd.webbb.post.infrastructure;
 
-import com.ddd.webbb.post.application.PostSearchCondition;
 import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostOrder;
 import com.ddd.webbb.post.domain.PostQueryRepository;
+import com.ddd.webbb.post.domain.PostSearchCondition;
 import com.ddd.webbb.post.domain.QPost;
 import com.ddd.webbb.user.domain.QUser;
 import com.ddd.webbb.user.domain.User;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -24,7 +26,14 @@ public class PostRepositoryImpl implements PostQueryRepository {
         return findByCursor(cursor, size, PostSearchCondition.empty());
     }
 
+    @Override
     public List<Post> findByCursor(Long cursor, int size, PostSearchCondition condition) {
+        return findByCursor(cursor, null, size, condition);
+    }
+
+    @Override
+    public List<Post> findByCursor(
+            Long cursor, Integer cursorLikeCount, int size, PostSearchCondition condition) {
         QPost post = QPost.post;
         QUser user = QUser.user;
         return queryFactory
@@ -33,10 +42,10 @@ public class PostRepositoryImpl implements PostQueryRepository {
                 .fetchJoin()
                 .where(
                         post.isDeleted.isFalse(),
-                        cursorCondition(post, cursor),
+                        cursorCondition(post, cursor, cursorLikeCount, condition),
                         jobRoleCondition(user, condition),
                         careerYearCondition(user, condition))
-                .orderBy(post.id.desc())
+                .orderBy(orderSpecifiers(post, condition))
                 .limit(size + 1L)
                 .fetch();
     }
@@ -55,8 +64,30 @@ public class PostRepositoryImpl implements PostQueryRepository {
                 .fetch();
     }
 
+    private BooleanExpression cursorCondition(
+            QPost post, Long cursor, Integer cursorLikeCount, PostSearchCondition condition) {
+        if (cursor == null) {
+            return null;
+        }
+
+        if (condition.order() == PostOrder.POPULAR && cursorLikeCount != null) {
+            return post.likeCount
+                    .lt(cursorLikeCount)
+                    .or(post.likeCount.eq(cursorLikeCount).and(post.id.lt(cursor)));
+        }
+
+        return post.id.lt(cursor);
+    }
+
     private BooleanExpression cursorCondition(QPost post, Long cursor) {
         return cursor != null ? post.id.lt(cursor) : null;
+    }
+
+    private OrderSpecifier<?>[] orderSpecifiers(QPost post, PostSearchCondition condition) {
+        if (condition.order() == PostOrder.POPULAR) {
+            return new OrderSpecifier<?>[] {post.likeCount.desc(), post.id.desc()};
+        }
+        return new OrderSpecifier<?>[] {post.id.desc()};
     }
 
     private BooleanExpression jobRoleCondition(QUser user, PostSearchCondition condition) {

--- a/src/main/java/com/ddd/webbb/post/interfaces/LikeController.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/LikeController.java
@@ -1,12 +1,15 @@
 package com.ddd.webbb.post.interfaces;
 
 import com.ddd.webbb.global.common.response.ApiResponse;
+import com.ddd.webbb.global.security.CustomUserPrincipal;
+import com.ddd.webbb.post.application.PostLikeService;
 import com.ddd.webbb.post.interfaces.dto.LikeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/posts/{postId}/likes")
 public class LikeController {
+
+    private final PostLikeService postLikeService;
+
+    public LikeController(PostLikeService postLikeService) {
+        this.postLikeService = postLikeService;
+    }
 
     @Operation(summary = "좋아요 등록")
     @ApiResponses({
@@ -42,10 +51,10 @@ public class LikeController {
                         """)))
     })
     @PostMapping
-    public ApiResponse<LikeResponse> like(@PathVariable Long postId) {
-        // TODO: 실제 서비스 연동
-        LikeResponse.MonsterInfo monster = new LikeResponse.MonsterInfo(70, 100, "ALIVE");
-        return ApiResponse.ok("좋아요를 등록했습니다.", new LikeResponse(postId, 4, monster));
+    public ApiResponse<LikeResponse> like(
+            @AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long postId) {
+        return ApiResponse.ok(
+                "좋아요를 등록했습니다.", postLikeService.addPostLike(principal.publicId(), postId));
     }
 
     @Operation(summary = "좋아요 취소")
@@ -72,9 +81,9 @@ public class LikeController {
                         """)))
     })
     @DeleteMapping("/me")
-    public ApiResponse<LikeResponse> unlike(@PathVariable Long postId) {
-        // TODO: 실제 서비스 연동
-        LikeResponse.MonsterInfo monster = new LikeResponse.MonsterInfo(80, 100, "ALIVE");
-        return ApiResponse.ok("좋아요를 취소했습니다.", new LikeResponse(postId, 3, monster));
+    public ApiResponse<LikeResponse> unlike(
+            @AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long postId) {
+        return ApiResponse.ok(
+                "좋아요를 취소했습니다.", postLikeService.removePostLike(principal.publicId(), postId));
     }
 }

--- a/src/main/java/com/ddd/webbb/post/interfaces/PostController.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/PostController.java
@@ -2,8 +2,9 @@ package com.ddd.webbb.post.interfaces;
 
 import com.ddd.webbb.global.common.response.ApiResponse;
 import com.ddd.webbb.global.security.CustomUserPrincipal;
-import com.ddd.webbb.post.application.PostSearchCondition;
 import com.ddd.webbb.post.application.PostService;
+import com.ddd.webbb.post.domain.PostOrder;
+import com.ddd.webbb.post.domain.PostSearchCondition;
 import com.ddd.webbb.post.interfaces.dto.PostCreateRequest;
 import com.ddd.webbb.post.interfaces.dto.PostCreateResponse;
 import com.ddd.webbb.post.interfaces.dto.PostDetailResponse;
@@ -163,6 +164,7 @@ public class PostController {
             summary = "게시글 목록 조회",
             description =
                     "게시글 목록을 커서 기반으로 조회합니다. "
+                            + "order로 최신순(LATEST) 또는 인기순(POPULAR)을 선택할 수 있습니다. "
                             + "jobRole과 careerYear는 반복 쿼리 파라미터로 다중 선택을 지원하며, "
                             + "작성자의 현재 프로필 정보(users.job_type, users.career_level)를 기준으로 필터링합니다. "
                             + "같은 필터 그룹 안에서는 OR 조건, 직군과 경력 조건 사이에서는 AND 조건으로 조합합니다. "
@@ -191,6 +193,7 @@ public class PostController {
                                 "emotionType": "ANXIETY",
                                 "monster": { "type": "ANXIETY_MONSTER", "hp": 80, "maxHp": 100, "status": "ALIVE" },
                                 "likeCount": 3,
+                                "likedByMe": true,
                                 "commentCount": 5,
                                 "createdAt": "2026-04-27T21:00:00"
                               }
@@ -203,8 +206,12 @@ public class PostController {
     })
     @GetMapping
     public ApiResponse<PostListResponse> getPosts(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @Parameter(description = "커서 (마지막 postId)") @RequestParam(required = false) Long cursor,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "정렬 방식. LATEST=최신순, POPULAR=인기순")
+                    @RequestParam(defaultValue = "LATEST")
+                    String order,
             @Parameter(
                             description =
                                     "직군 필터. 반복 파라미터로 다중 선택 가능. "
@@ -225,10 +232,14 @@ public class PostController {
                     List<String> careerYear) {
         return ApiResponse.ok(
                 "게시글 목록을 조회했습니다.",
-                postService.getPosts(cursor, size, new PostSearchCondition(jobRole, careerYear)));
+                postService.getPosts(
+                        principal != null ? principal.publicId() : null,
+                        cursor,
+                        size,
+                        new PostSearchCondition(jobRole, careerYear, PostOrder.from(order))));
     }
 
-    @Operation(summary = "게시글 상세 조회")
+    @Operation(summary = "게시글 상세 조회", description = "게시글 본문과 댓글 목록을 함께 조회합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -250,9 +261,20 @@ public class PostController {
                             "emotion": { "type": "ANXIETY", "displayName": "불안" },
                             "monster": { "type": "ANXIETY_MONSTER", "hp": 80, "maxHp": 100, "status": "ALIVE" },
                             "likeCount": 3,
+                            "likedByMe": true,
                             "commentCount": 1,
                             "comments": [
-                              { "commentId": 1, "authorNickname": "anonymous", "content": "힘내세요!", "createdAt": "2026-04-27T21:30:00" }
+                              {
+                                "commentId": 1,
+                                "authorId": "01939b10-7b0f-7c8f-9a2b-222222222222",
+                                "authorNickname": "anonymous",
+                                "jobRole": "PLANNING",
+                                "careerYear": "YEAR_1",
+                                "content": "힘내세요!",
+                                "likeCount": 2,
+                                "likedByMe": false,
+                                "createdAt": "2026-04-27T21:30:00"
+                              }
                             ],
                             "createdAt": "2026-04-27T21:00:00"
                           },
@@ -261,8 +283,11 @@ public class PostController {
                         """)))
     })
     @GetMapping("/{postId}")
-    public ApiResponse<PostDetailResponse> getPost(@PathVariable Long postId) {
-        return ApiResponse.ok("게시글을 조회했습니다.", postService.getPostDetail(postId));
+    public ApiResponse<PostDetailResponse> getPost(
+            @AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long postId) {
+        return ApiResponse.ok(
+                "게시글을 조회했습니다.",
+                postService.getPostDetail(principal != null ? principal.publicId() : null, postId));
     }
 
     @Operation(summary = "게시글 수정")

--- a/src/main/java/com/ddd/webbb/post/interfaces/dto/LikeResponse.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/dto/LikeResponse.java
@@ -1,6 +1,16 @@
 package com.ddd.webbb.post.interfaces.dto;
 
+import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.post.domain.Post;
+
 public record LikeResponse(Long postId, int likeCount, MonsterInfo monster) {
 
     public record MonsterInfo(int hp, int maxHp, String status) {}
+
+    public static LikeResponse of(Post post, Monster monster) {
+        return new LikeResponse(
+                post.getId(),
+                post.getLikeCount(),
+                new MonsterInfo(monster.getHp(), monster.getMaxHp(), monster.getStatus().name()));
+    }
 }

--- a/src/main/java/com/ddd/webbb/post/interfaces/dto/PostDetailResponse.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/dto/PostDetailResponse.java
@@ -11,6 +11,7 @@ public record PostDetailResponse(
         EmotionInfo emotion,
         MonsterInfo monster,
         int likeCount,
+        boolean likedByMe,
         int commentCount,
         List<CommentInfo> comments,
         LocalDateTime createdAt) {
@@ -22,5 +23,13 @@ public record PostDetailResponse(
     public record MonsterInfo(String type, int hp, int maxHp, String status) {}
 
     public record CommentInfo(
-            Long commentId, String authorNickname, String content, LocalDateTime createdAt) {}
+            Long commentId,
+            String authorId,
+            String authorNickname,
+            String jobRole,
+            String careerYear,
+            String content,
+            int likeCount,
+            boolean likedByMe,
+            LocalDateTime createdAt) {}
 }

--- a/src/main/java/com/ddd/webbb/post/interfaces/dto/PostListResponse.java
+++ b/src/main/java/com/ddd/webbb/post/interfaces/dto/PostListResponse.java
@@ -14,6 +14,7 @@ public record PostListResponse(List<PostSummary> posts, Long nextCursor) {
             String emotionType,
             MonsterInfo monster,
             int likeCount,
+            boolean likedByMe,
             int commentCount,
             LocalDateTime createdAt) {}
 

--- a/src/main/java/com/ddd/webbb/user/application/UserService.java
+++ b/src/main/java/com/ddd/webbb/user/application/UserService.java
@@ -59,10 +59,8 @@ public class UserService {
 
     @Transactional
     public UserResponse updateUser(UUID publicId, UserUpdateRequest request) {
-        User user =
-                userRepository
-                        .findByPublicIdAndDeletedAtIsNull(publicId)
-                        .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+        User user = getUserEntity(publicId);
+        validateNicknameForUpdate(user, request.nickname());
         user.update(
                 request.nickname(),
                 request.jobType() != null ? request.jobType().name() : null,
@@ -71,11 +69,25 @@ public class UserService {
     }
 
     @Transactional
+    public User updateProfile(UUID publicId, String nickname, String jobType, String careerLevel) {
+        User user = getUserEntity(publicId);
+        validateNicknameForUpdate(user, nickname);
+        user.update(nickname, jobType, careerLevel);
+        return user;
+    }
+
+    @Transactional
     public void withdrawUser(UUID publicId) {
-        User user =
-                userRepository
-                        .findByPublicIdAndDeletedAtIsNull(publicId)
-                        .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+        User user = getUserEntity(publicId);
         user.withdraw();
+    }
+
+    private void validateNicknameForUpdate(User user, String nickname) {
+        if (nickname == null || nickname.equals(user.getNickname())) {
+            return;
+        }
+        if (userRepository.existsByNicknameAndDeletedAtIsNull(nickname)) {
+            throw new AppException(ErrorCode.DUPLICATED_NICKNAME);
+        }
     }
 }

--- a/src/main/java/com/ddd/webbb/user/interfaces/UserController.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/UserController.java
@@ -1,6 +1,7 @@
 package com.ddd.webbb.user.interfaces;
 
 import com.ddd.webbb.global.common.response.ApiResponse;
+import com.ddd.webbb.global.security.CustomUserPrincipal;
 import com.ddd.webbb.user.application.UserService;
 import com.ddd.webbb.user.interfaces.dto.NicknameCheckResponse;
 import com.ddd.webbb.user.interfaces.dto.UserCreateRequest;
@@ -19,10 +20,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -350,17 +351,9 @@ public class UserController {
                         """)))
     })
     @GetMapping("/me")
-    public ApiResponse<UserMeResponse> getMe() {
-        // TODO: 실제 서비스 연동
-        return ApiResponse.ok(
-                new UserMeResponse(
-                        UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
-                        "test@test.com",
-                        "ogu",
-                        "DEVELOPMENT",
-                        "YEAR_3",
-                        true,
-                        LocalDateTime.of(2026, 5, 3, 12, 0)));
+    public ApiResponse<UserMeResponse> getMe(
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        return ApiResponse.ok(UserMeResponse.from(userService.getUserEntity(principal.publicId())));
     }
 
     @Operation(
@@ -417,16 +410,16 @@ public class UserController {
     })
     @PatchMapping("/me/profile")
     public ApiResponse<UserMeResponse> updateMyProfile(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestBody @Valid UserProfileUpdateRequest request) {
-        // TODO: 실제 서비스 연동
         return ApiResponse.ok(
-                new UserMeResponse(
-                        UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
-                        "test@test.com",
-                        request.nickname() != null ? request.nickname() : "ogu",
-                        request.jobType() != null ? request.jobType().name() : "DEVELOPMENT",
-                        request.careerLevel() != null ? request.careerLevel().name() : "YEAR_3",
-                        true,
-                        LocalDateTime.of(2026, 5, 3, 12, 0)));
+                UserMeResponse.from(
+                        userService.updateProfile(
+                                principal.publicId(),
+                                request.nickname(),
+                                request.jobType() != null ? request.jobType().name() : null,
+                                request.careerLevel() != null
+                                        ? request.careerLevel().name()
+                                        : null)));
     }
 }

--- a/src/main/java/com/ddd/webbb/user/interfaces/dto/UserMeResponse.java
+++ b/src/main/java/com/ddd/webbb/user/interfaces/dto/UserMeResponse.java
@@ -1,5 +1,6 @@
 package com.ddd.webbb.user.interfaces.dto;
 
+import com.ddd.webbb.user.domain.User;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -10,4 +11,16 @@ public record UserMeResponse(
         String jobType,
         String careerLevel,
         boolean isActive,
-        LocalDateTime createdAt) {}
+        LocalDateTime createdAt) {
+
+    public static UserMeResponse from(User user) {
+        return new UserMeResponse(
+                user.getPublicId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getJobType(),
+                user.getCareerLevel(),
+                user.isActive(),
+                user.getCreatedAt());
+    }
+}

--- a/src/test/java/com/ddd/webbb/global/config/SwaggerConfigTest.java
+++ b/src/test/java/com/ddd/webbb/global/config/SwaggerConfigTest.java
@@ -41,19 +41,6 @@ class SwaggerConfigTest {
     }
 
     @Test
-    void 스텁_api는_stub_prefix를_붙인다() throws Exception {
-        OperationCustomizer customizer = swaggerConfig.apiStatusOperationCustomizer();
-        HandlerMethod handlerMethod =
-                new HandlerMethod(
-                        new UserController(null), UserController.class.getMethod("getMe"));
-        Operation operation = new Operation().summary("내 정보 조회");
-
-        Operation customized = customizer.customize(operation, handlerMethod);
-
-        assertThat(customized.getSummary()).isEqualTo("[STUB] 내 정보 조회");
-    }
-
-    @Test
     void 테스트_api는_test_prefix를_붙인다() throws Exception {
         OperationCustomizer customizer = swaggerConfig.apiStatusOperationCustomizer();
         HandlerMethod handlerMethod =

--- a/src/test/java/com/ddd/webbb/post/application/PostLikeServiceTest.java
+++ b/src/test/java/com/ddd/webbb/post/application/PostLikeServiceTest.java
@@ -1,0 +1,128 @@
+package com.ddd.webbb.post.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ddd.webbb.category.domain.BoardCategory;
+import com.ddd.webbb.category.domain.BoardCategoryRepository;
+import com.ddd.webbb.config.TestRedisConfig;
+import com.ddd.webbb.emotion.domain.EmotionType;
+import com.ddd.webbb.global.common.exception.AppException;
+import com.ddd.webbb.global.common.exception.ErrorCode;
+import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.monster.domain.MonsterRepository;
+import com.ddd.webbb.post.domain.CommentTone;
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostLikeRepository;
+import com.ddd.webbb.post.domain.PostRepository;
+import com.ddd.webbb.post.interfaces.dto.LikeResponse;
+import com.ddd.webbb.user.domain.User;
+import com.ddd.webbb.user.domain.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Import(TestRedisConfig.class)
+@Transactional
+class PostLikeServiceTest {
+
+    @Autowired private PostLikeService postLikeService;
+    @Autowired private PostLikeRepository postLikeRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private PostRepository postRepository;
+    @Autowired private MonsterRepository monsterRepository;
+    @Autowired private BoardCategoryRepository boardCategoryRepository;
+
+    private User user;
+    private Post post;
+    private Monster monster;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.saveAndFlush(User.create("liker@test.com", "공감러"));
+        User author = userRepository.saveAndFlush(User.create("author@test.com", "작성자"));
+        BoardCategory category =
+                boardCategoryRepository.saveAndFlush(BoardCategory.create("멘탈케어", "기본 카테고리", 0));
+        post =
+                postRepository.saveAndFlush(
+                        Post.create(author, category, "제목", "내용", CommentTone.COMFORT_ME));
+        monster = monsterRepository.saveAndFlush(Monster.create(post, EmotionType.ANXIETY, 30));
+    }
+
+    @Nested
+    @DisplayName("게시글 좋아요 등록")
+    class AddPostLike {
+
+        @Test
+        @DisplayName("정상 좋아요 → likeCount 증가 + 몬스터 HP 감소")
+        void success() {
+            LikeResponse response = postLikeService.addPostLike(user.getPublicId(), post.getId());
+
+            assertThat(response.postId()).isEqualTo(post.getId());
+            assertThat(response.likeCount()).isEqualTo(1);
+            assertThat(response.monster().hp()).isEqualTo(29);
+            assertThat(post.getLikeCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("중복 좋아요 → ALREADY_LIKED_POST 예외")
+        void duplicateLike() {
+            postLikeService.addPostLike(user.getPublicId(), post.getId());
+
+            assertThatThrownBy(() -> postLikeService.addPostLike(user.getPublicId(), post.getId()))
+                    .isInstanceOf(AppException.class)
+                    .satisfies(
+                            e ->
+                                    assertThat(((AppException) e).getErrorCode())
+                                            .isEqualTo(ErrorCode.ALREADY_LIKED_POST));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 게시글에 좋아요 → POST_NOT_FOUND 예외")
+        void postNotFound() {
+            assertThatThrownBy(() -> postLikeService.addPostLike(user.getPublicId(), 9999L))
+                    .isInstanceOf(AppException.class)
+                    .satisfies(
+                            e ->
+                                    assertThat(((AppException) e).getErrorCode())
+                                            .isEqualTo(ErrorCode.POST_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 좋아요 취소")
+    class RemovePostLike {
+
+        @Test
+        @DisplayName("정상 좋아요 취소 → likeCount 감소")
+        void success() {
+            postLikeService.addPostLike(user.getPublicId(), post.getId());
+
+            LikeResponse response =
+                    postLikeService.removePostLike(user.getPublicId(), post.getId());
+
+            assertThat(response.postId()).isEqualTo(post.getId());
+            assertThat(response.likeCount()).isEqualTo(0);
+            assertThat(post.getLikeCount()).isEqualTo(0);
+            assertThat(postLikeRepository.existsByPostAndUser(post, user)).isFalse();
+        }
+
+        @Test
+        @DisplayName("좋아요하지 않은 게시글 취소 → POST_LIKE_NOT_FOUND 예외")
+        void likeNotFound() {
+            assertThatThrownBy(
+                            () -> postLikeService.removePostLike(user.getPublicId(), post.getId()))
+                    .isInstanceOf(AppException.class)
+                    .satisfies(
+                            e ->
+                                    assertThat(((AppException) e).getErrorCode())
+                                            .isEqualTo(ErrorCode.POST_LIKE_NOT_FOUND));
+        }
+    }
+}

--- a/src/test/java/com/ddd/webbb/post/application/PostServiceTest.java
+++ b/src/test/java/com/ddd/webbb/post/application/PostServiceTest.java
@@ -13,6 +13,9 @@ import com.ddd.webbb.ai.application.AiAnalysisService;
 import com.ddd.webbb.category.domain.BoardCategory;
 import com.ddd.webbb.category.domain.BoardCategoryRepository;
 import com.ddd.webbb.comment.application.CommentService;
+import com.ddd.webbb.comment.domain.Comment;
+import com.ddd.webbb.comment.domain.CommentLike;
+import com.ddd.webbb.comment.domain.CommentLikeRepository;
 import com.ddd.webbb.emotion.application.PostEmotionService;
 import com.ddd.webbb.emotion.domain.EmotionType;
 import com.ddd.webbb.global.common.exception.AppException;
@@ -21,10 +24,16 @@ import com.ddd.webbb.monster.application.MonsterService;
 import com.ddd.webbb.monster.domain.Monster;
 import com.ddd.webbb.post.domain.CommentTone;
 import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostLike;
+import com.ddd.webbb.post.domain.PostLikeRepository;
+import com.ddd.webbb.post.domain.PostOrder;
+import com.ddd.webbb.post.domain.PostQueryRepository;
 import com.ddd.webbb.post.domain.PostRepository;
-import com.ddd.webbb.post.infrastructure.PostRepositoryImpl;
+import com.ddd.webbb.post.domain.PostSearchCondition;
 import com.ddd.webbb.post.interfaces.dto.PostCreateRequest;
 import com.ddd.webbb.post.interfaces.dto.PostCreateResponse;
+import com.ddd.webbb.post.interfaces.dto.PostDetailResponse;
+import com.ddd.webbb.post.interfaces.dto.PostListResponse;
 import com.ddd.webbb.user.application.UserService;
 import com.ddd.webbb.user.domain.User;
 import java.time.LocalDateTime;
@@ -38,51 +47,170 @@ import org.springframework.test.util.ReflectionTestUtils;
 class PostServiceTest {
 
     private PostRepository postRepository;
-    private PostRepositoryImpl postRepositoryImpl;
+    private PostQueryRepository postQueryRepository;
+    private PostLikeRepository postLikeRepository;
     private BoardCategoryRepository boardCategoryRepository;
     private UserService userService;
     private AiAnalysisService aiAnalysisService;
     private MonsterService monsterService;
     private PostEmotionService postEmotionService;
     private CommentService commentService;
+    private CommentLikeRepository commentLikeRepository;
     private PostService postService;
 
     @BeforeEach
     void setUp() {
         postRepository = mock(PostRepository.class);
-        postRepositoryImpl = mock(PostRepositoryImpl.class);
+        postQueryRepository = mock(PostQueryRepository.class);
+        postLikeRepository = mock(PostLikeRepository.class);
         boardCategoryRepository = mock(BoardCategoryRepository.class);
         userService = mock(UserService.class);
         aiAnalysisService = mock(AiAnalysisService.class);
         monsterService = mock(MonsterService.class);
         postEmotionService = mock(PostEmotionService.class);
         commentService = mock(CommentService.class);
+        commentLikeRepository = mock(CommentLikeRepository.class);
         postService =
                 new PostService(
                         postRepository,
-                        postRepositoryImpl,
+                        postQueryRepository,
+                        postLikeRepository,
                         boardCategoryRepository,
                         userService,
                         aiAnalysisService,
                         monsterService,
                         postEmotionService,
-                        commentService);
+                        commentService,
+                        commentLikeRepository);
     }
 
     @Test
     void 게시글_목록_조회_필터_조건을_레포지토리에_전달한다() {
         PostSearchCondition condition =
-                new PostSearchCondition(List.of("PLANNING", "DESIGN"), List.of("YEAR_3"));
-        given(postRepositoryImpl.findByCursor(eq(null), eq(20), any(PostSearchCondition.class)))
+                new PostSearchCondition(
+                        List.of("PLANNING", "DESIGN"), List.of("YEAR_3"), PostOrder.LATEST);
+        given(
+                        postQueryRepository.findByCursor(
+                                eq(null), eq(null), eq(20), any(PostSearchCondition.class)))
                 .willReturn(List.of());
 
         postService.getPosts(null, 20, condition);
 
         ArgumentCaptor<PostSearchCondition> conditionCaptor =
                 ArgumentCaptor.forClass(PostSearchCondition.class);
-        verify(postRepositoryImpl).findByCursor(eq(null), eq(20), conditionCaptor.capture());
+        verify(postQueryRepository)
+                .findByCursor(eq(null), eq(null), eq(20), conditionCaptor.capture());
         assertThat(conditionCaptor.getValue().jobRoles()).containsExactly("PLANNING", "DESIGN");
         assertThat(conditionCaptor.getValue().careerYears()).containsExactly("YEAR_3");
+        assertThat(conditionCaptor.getValue().order()).isEqualTo(PostOrder.LATEST);
+    }
+
+    @Test
+    void 인기순_조회는_커서_게시글의_좋아요수를_함께_전달한다() {
+        UUID cursorAuthorId = UUID.randomUUID();
+        User author = User.create("cursor@test.com", "cursor");
+        ReflectionTestUtils.setField(author, "publicId", cursorAuthorId);
+        BoardCategory category = BoardCategory.create("멘탈케어", "기본 글 작성 카테고리", 0);
+        Post cursorPost = Post.create(author, category, "기준 글", "기준 글", CommentTone.COMFORT_ME);
+        cursorPost.incrementLikeCount();
+        cursorPost.incrementLikeCount();
+        cursorPost.incrementLikeCount();
+        cursorPost.incrementLikeCount();
+        cursorPost.incrementLikeCount();
+        ReflectionTestUtils.setField(cursorPost, "id", 99L);
+
+        PostSearchCondition condition =
+                new PostSearchCondition(List.of(), List.of(), PostOrder.POPULAR);
+        given(postRepository.findByIdAndIsDeletedFalse(99L))
+                .willReturn(java.util.Optional.of(cursorPost));
+        given(postQueryRepository.findByCursor(eq(99L), eq(5), eq(20), eq(condition)))
+                .willReturn(List.of());
+
+        postService.getPosts(99L, 20, condition);
+
+        verify(postQueryRepository).findByCursor(eq(99L), eq(5), eq(20), eq(condition));
+    }
+
+    @Test
+    void 로그인한_사용자의_좋아요_여부를_목록에_반영한다() {
+        UUID viewerId = UUID.randomUUID();
+        UUID authorId = UUID.randomUUID();
+        User viewer = User.create("viewer@test.com", "viewer");
+        ReflectionTestUtils.setField(viewer, "publicId", viewerId);
+        User author = User.create("author@test.com", "author");
+        ReflectionTestUtils.setField(author, "publicId", authorId);
+        ReflectionTestUtils.setField(author, "jobType", "DEVELOPMENT");
+        ReflectionTestUtils.setField(author, "careerLevel", "YEAR_3");
+        BoardCategory category = BoardCategory.create("멘탈케어", "기본 글 작성 카테고리", 0);
+        Post post = Post.create(author, category, "제목", "내용", CommentTone.COMFORT_ME);
+        ReflectionTestUtils.setField(post, "id", 1L);
+        Monster monster = Monster.create(post, EmotionType.ANXIETY, 30);
+        com.ddd.webbb.emotion.domain.PostEmotion postEmotion =
+                mock(com.ddd.webbb.emotion.domain.PostEmotion.class);
+        given(postEmotion.getPost()).willReturn(post);
+        given(postEmotion.getEmotionType()).willReturn(EmotionType.ANXIETY);
+
+        given(userService.getUserEntity(viewerId)).willReturn(viewer);
+        given(
+                        postQueryRepository.findByCursor(
+                                eq(null), eq(null), eq(20), any(PostSearchCondition.class)))
+                .willReturn(List.of(post));
+        given(postEmotionService.findByPostIds(List.of(1L))).willReturn(List.of(postEmotion));
+        given(monsterService.findByPostIds(List.of(1L))).willReturn(List.of(monster));
+        given(postLikeRepository.findByPost_IdInAndUser(List.of(1L), viewer))
+                .willReturn(List.of(PostLike.create(post, viewer)));
+
+        PostListResponse response =
+                postService.getPosts(viewerId, null, 20, PostSearchCondition.empty());
+
+        assertThat(response.posts()).hasSize(1);
+        assertThat(response.posts().get(0).likedByMe()).isTrue();
+    }
+
+    @Test
+    void 게시글_상세에_댓글_작성자_메타와_공감여부를_포함한다() {
+        UUID viewerId = UUID.randomUUID();
+        UUID authorId = UUID.randomUUID();
+        UUID commentAuthorId = UUID.randomUUID();
+        User viewer = User.create("viewer@test.com", "viewer");
+        ReflectionTestUtils.setField(viewer, "publicId", viewerId);
+        User author = User.create("author@test.com", "author");
+        ReflectionTestUtils.setField(author, "publicId", authorId);
+        ReflectionTestUtils.setField(author, "jobType", "DEVELOPMENT");
+        ReflectionTestUtils.setField(author, "careerLevel", "YEAR_3");
+        User commentAuthor = User.create("helper@test.com", "helper");
+        ReflectionTestUtils.setField(commentAuthor, "publicId", commentAuthorId);
+        ReflectionTestUtils.setField(commentAuthor, "jobType", "PLANNING");
+        ReflectionTestUtils.setField(commentAuthor, "careerLevel", "YEAR_1");
+        BoardCategory category = BoardCategory.create("멘탈케어", "기본 글 작성 카테고리", 0);
+        Post post = Post.create(author, category, "제목", "내용", CommentTone.COMFORT_ME);
+        ReflectionTestUtils.setField(post, "id", 1L);
+        Comment comment = Comment.create(post, commentAuthor, null, "힘내세요!");
+        ReflectionTestUtils.setField(comment, "id", 10L);
+        comment.incrementLikeCount();
+        comment.incrementLikeCount();
+        Monster monster = Monster.create(post, EmotionType.ANXIETY, 30);
+        com.ddd.webbb.emotion.domain.PostEmotion postEmotion =
+                mock(com.ddd.webbb.emotion.domain.PostEmotion.class);
+        given(postEmotion.getEmotionType()).willReturn(EmotionType.ANXIETY);
+
+        given(userService.getUserEntity(viewerId)).willReturn(viewer);
+        given(postRepository.findByIdAndIsDeletedFalse(1L)).willReturn(java.util.Optional.of(post));
+        given(postEmotionService.findByPost(1L)).willReturn(postEmotion);
+        given(monsterService.findByPost(1L)).willReturn(monster);
+        given(commentService.findCommentsByPost(1L)).willReturn(List.of(comment));
+        given(postLikeRepository.existsByPostAndUser(post, viewer)).willReturn(true);
+        given(commentLikeRepository.findByComment_IdInAndUser(List.of(10L), viewer))
+                .willReturn(List.of(CommentLike.create(comment, viewer)));
+
+        PostDetailResponse response = postService.getPostDetail(viewerId, 1L);
+
+        assertThat(response.likedByMe()).isTrue();
+        assertThat(response.comments()).hasSize(1);
+        assertThat(response.comments().get(0).authorId()).isEqualTo(commentAuthorId.toString());
+        assertThat(response.comments().get(0).jobRole()).isEqualTo("PLANNING");
+        assertThat(response.comments().get(0).careerYear()).isEqualTo("YEAR_1");
+        assertThat(response.comments().get(0).likedByMe()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/ddd/webbb/post/infrastructure/PostRepositoryImplTest.java
+++ b/src/test/java/com/ddd/webbb/post/infrastructure/PostRepositoryImplTest.java
@@ -4,9 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ddd.webbb.category.domain.BoardCategory;
 import com.ddd.webbb.global.config.JpaConfig;
-import com.ddd.webbb.post.application.PostSearchCondition;
 import com.ddd.webbb.post.domain.CommentTone;
 import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostOrder;
+import com.ddd.webbb.post.domain.PostSearchCondition;
 import com.ddd.webbb.user.domain.User;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,10 @@ class PostRepositoryImplTest {
                 postRepositoryImpl.findByCursor(
                         null,
                         10,
-                        new PostSearchCondition(List.of("PLANNING", "DESIGN"), List.of("YEAR_3")));
+                        new PostSearchCondition(
+                                List.of("PLANNING", "DESIGN"),
+                                List.of("YEAR_3"),
+                                PostOrder.LATEST));
 
         assertThat(posts)
                 .extracting(Post::getId)
@@ -56,7 +60,7 @@ class PostRepositoryImplTest {
                 postRepositoryImpl.findByCursor(
                         second.getId(),
                         10,
-                        new PostSearchCondition(List.of("PLANNING"), List.of()));
+                        new PostSearchCondition(List.of("PLANNING"), List.of(), PostOrder.LATEST));
 
         assertThat(posts).extracting(Post::getId).containsExactly(first.getId());
     }
@@ -71,6 +75,53 @@ class PostRepositoryImplTest {
         List<Post> posts = postRepositoryImpl.findByCursor(null, 10, PostSearchCondition.empty());
 
         assertThat(posts).extracting(Post::getId).containsExactly(second.getId(), first.getId());
+    }
+
+    @Test
+    void 인기순으로_좋아요수와_id_기준_정렬한다() {
+        BoardCategory category = persistCategory();
+        Post low = persistPost("low@test.com", "낮음", "PLANNING", "YEAR_1", category);
+        Post middle = persistPost("middle@test.com", "중간", "DESIGN", "YEAR_3", category);
+        Post high = persistPost("high@test.com", "높음", "DEVELOPMENT", "YEAR_5", category);
+        incrementLikes(low, 1);
+        incrementLikes(middle, 3);
+        incrementLikes(high, 3);
+        flushAndClear();
+
+        List<Post> posts =
+                postRepositoryImpl.findByCursor(
+                        null,
+                        null,
+                        10,
+                        new PostSearchCondition(List.of(), List.of(), PostOrder.POPULAR));
+
+        assertThat(posts)
+                .extracting(Post::getId)
+                .containsExactly(high.getId(), middle.getId(), low.getId());
+    }
+
+    @Test
+    void 인기순_커서는_좋아요수와_id를_함께_사용한다() {
+        BoardCategory category = persistCategory();
+        Post highest = persistPost("highest@test.com", "최상", "PLANNING", "YEAR_1", category);
+        Post middleOlder = persistPost("middle-old@test.com", "중간옛날", "DESIGN", "YEAR_3", category);
+        Post middleNewer =
+                persistPost("middle-new@test.com", "중간최신", "DEVELOPMENT", "YEAR_5", category);
+        Post low = persistPost("low2@test.com", "낮음2", "MARKETING", "YEAR_2", category);
+        incrementLikes(highest, 5);
+        incrementLikes(middleOlder, 3);
+        incrementLikes(middleNewer, 3);
+        incrementLikes(low, 1);
+        flushAndClear();
+
+        List<Post> posts =
+                postRepositoryImpl.findByCursor(
+                        middleNewer.getId(),
+                        3,
+                        10,
+                        new PostSearchCondition(List.of(), List.of(), PostOrder.POPULAR));
+
+        assertThat(posts).extracting(Post::getId).containsExactly(middleOlder.getId(), low.getId());
     }
 
     private BoardCategory persistCategory() {
@@ -97,5 +148,11 @@ class PostRepositoryImplTest {
     private void flushAndClear() {
         entityManager.flush();
         entityManager.clear();
+    }
+
+    private void incrementLikes(Post post, int count) {
+        for (int i = 0; i < count; i++) {
+            post.incrementLikeCount();
+        }
     }
 }

--- a/src/test/java/com/ddd/webbb/post/interfaces/LikeControllerTest.java
+++ b/src/test/java/com/ddd/webbb/post/interfaces/LikeControllerTest.java
@@ -1,0 +1,180 @@
+package com.ddd.webbb.post.interfaces;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ddd.webbb.global.auth.CustomOAuth2UserService;
+import com.ddd.webbb.global.auth.JwtAuthFilter;
+import com.ddd.webbb.global.auth.JwtAuthenticationEntryPoint;
+import com.ddd.webbb.global.auth.JwtProvider;
+import com.ddd.webbb.global.auth.OAuth2LoginFailureHandler;
+import com.ddd.webbb.global.auth.OAuth2LoginSuccessHandler;
+import com.ddd.webbb.global.auth.RedisOAuth2AuthorizationRequestRepository;
+import com.ddd.webbb.global.common.exception.AppException;
+import com.ddd.webbb.global.common.exception.ErrorCode;
+import com.ddd.webbb.global.config.SecurityConfig;
+import com.ddd.webbb.global.security.CustomUserPrincipal;
+import com.ddd.webbb.post.application.PostLikeService;
+import com.ddd.webbb.post.interfaces.dto.LikeResponse;
+import com.ddd.webbb.user.application.UserService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LikeController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class, JwtAuthenticationEntryPoint.class})
+@ActiveProfiles("test")
+class LikeControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private PostLikeService postLikeService;
+    @MockitoBean private UserService userService;
+    @MockitoBean private JwtProvider jwtProvider;
+    @MockitoBean private CustomOAuth2UserService customOAuth2UserService;
+    @MockitoBean private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    @MockitoBean private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    @MockitoBean private RedisOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+    @Nested
+    @DisplayName("게시글 좋아요 등록")
+    class CreatePostLike {
+
+        @Test
+        @DisplayName("정상 좋아요 → 200")
+        void success() throws Exception {
+            UUID userId = UUID.randomUUID();
+            CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "ogu");
+            LikeResponse response =
+                    new LikeResponse(1L, 4, new LikeResponse.MonsterInfo(29, 30, "ALIVE"));
+
+            given(postLikeService.addPostLike(userId, 1L)).willReturn(response);
+
+            mockMvc.perform(
+                            post("/api/posts/{postId}/likes", 1L)
+                                    .with(
+                                            authentication(
+                                                    new UsernamePasswordAuthenticationToken(
+                                                            principal, null, List.of()))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.postId").value(1L))
+                    .andExpect(jsonPath("$.data.likeCount").value(4))
+                    .andExpect(jsonPath("$.data.monster.hp").value(29));
+        }
+
+        @Test
+        @DisplayName("미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/posts/{postId}/likes", 1L))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 게시글 → 404")
+        void postNotFound() throws Exception {
+            UUID userId = UUID.randomUUID();
+            CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "ogu");
+            willThrow(new AppException(ErrorCode.POST_NOT_FOUND))
+                    .given(postLikeService)
+                    .addPostLike(userId, 99L);
+
+            mockMvc.perform(
+                            post("/api/posts/{postId}/likes", 99L)
+                                    .with(
+                                            authentication(
+                                                    new UsernamePasswordAuthenticationToken(
+                                                            principal, null, List.of()))))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value("존재하지 않는 게시글입니다."));
+        }
+
+        @Test
+        @DisplayName("중복 좋아요 → 409")
+        void alreadyLiked() throws Exception {
+            UUID userId = UUID.randomUUID();
+            CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "ogu");
+            willThrow(new AppException(ErrorCode.ALREADY_LIKED_POST))
+                    .given(postLikeService)
+                    .addPostLike(userId, 1L);
+
+            mockMvc.perform(
+                            post("/api/posts/{postId}/likes", 1L)
+                                    .with(
+                                            authentication(
+                                                    new UsernamePasswordAuthenticationToken(
+                                                            principal, null, List.of()))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value("이미 좋아요한 게시글입니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 좋아요 취소")
+    class DeletePostLike {
+
+        @Test
+        @DisplayName("정상 취소 → 200")
+        void success() throws Exception {
+            UUID userId = UUID.randomUUID();
+            CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "ogu");
+            LikeResponse response =
+                    new LikeResponse(1L, 3, new LikeResponse.MonsterInfo(29, 30, "ALIVE"));
+            given(postLikeService.removePostLike(userId, 1L)).willReturn(response);
+
+            mockMvc.perform(
+                            delete("/api/posts/{postId}/likes/me", 1L)
+                                    .with(
+                                            authentication(
+                                                    new UsernamePasswordAuthenticationToken(
+                                                            principal, null, List.of()))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("좋아요를 취소했습니다."))
+                    .andExpect(jsonPath("$.data.postId").value(1L))
+                    .andExpect(jsonPath("$.data.likeCount").value(3));
+        }
+
+        @Test
+        @DisplayName("미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(delete("/api/posts/{postId}/likes/me", 1L))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("좋아요 기록 없음 → 404")
+        void likeNotFound() throws Exception {
+            UUID userId = UUID.randomUUID();
+            CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "ogu");
+            willThrow(new AppException(ErrorCode.POST_LIKE_NOT_FOUND))
+                    .given(postLikeService)
+                    .removePostLike(userId, 1L);
+
+            mockMvc.perform(
+                            delete("/api/posts/{postId}/likes/me", 1L)
+                                    .with(
+                                            authentication(
+                                                    new UsernamePasswordAuthenticationToken(
+                                                            principal, null, List.of()))))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value("좋아요 기록이 존재하지 않습니다."));
+        }
+    }
+}

--- a/src/test/java/com/ddd/webbb/post/interfaces/PostControllerTest.java
+++ b/src/test/java/com/ddd/webbb/post/interfaces/PostControllerTest.java
@@ -24,11 +24,13 @@ import com.ddd.webbb.global.common.exception.AppException;
 import com.ddd.webbb.global.common.exception.ErrorCode;
 import com.ddd.webbb.global.config.SecurityConfig;
 import com.ddd.webbb.global.security.CustomUserPrincipal;
-import com.ddd.webbb.post.application.PostSearchCondition;
 import com.ddd.webbb.post.application.PostService;
 import com.ddd.webbb.post.domain.CommentTone;
+import com.ddd.webbb.post.domain.PostOrder;
+import com.ddd.webbb.post.domain.PostSearchCondition;
 import com.ddd.webbb.post.interfaces.dto.PostCreateRequest;
 import com.ddd.webbb.post.interfaces.dto.PostCreateResponse;
+import com.ddd.webbb.post.interfaces.dto.PostDetailResponse;
 import com.ddd.webbb.post.interfaces.dto.PostListResponse;
 import com.ddd.webbb.user.application.UserService;
 import java.time.LocalDateTime;
@@ -62,12 +64,19 @@ class PostControllerTest {
     @MockitoBean private RedisOAuth2AuthorizationRequestRepository authorizationRequestRepository;
 
     @Test
-    void 게시글_목록_조회는_직군과_경력_다중_필터를_서비스에_전달한다() throws Exception {
-        given(postService.getPosts(eq(null), eq(20), any(PostSearchCondition.class)))
+    void 게시글_목록_조회는_정렬과_필터를_서비스에_전달한다() throws Exception {
+        UUID userId = UUID.randomUUID();
+        CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "ogu");
+        given(postService.getPosts(eq(userId), eq(null), eq(20), any(PostSearchCondition.class)))
                 .willReturn(new PostListResponse(List.of(), null));
 
         mockMvc.perform(
                         get("/api/posts")
+                                .with(
+                                        authentication(
+                                                new UsernamePasswordAuthenticationToken(
+                                                        principal, null, List.of())))
+                                .param("order", "popular")
                                 .param("jobRole", "PLANNING", "DESIGN")
                                 .param("careerYear", "YEAR_3")
                                 .param("size", "20"))
@@ -77,13 +86,63 @@ class PostControllerTest {
 
         ArgumentCaptor<PostSearchCondition> conditionCaptor =
                 ArgumentCaptor.forClass(PostSearchCondition.class);
-        verify(postService).getPosts(eq(null), eq(20), conditionCaptor.capture());
+        verify(postService).getPosts(eq(userId), eq(null), eq(20), conditionCaptor.capture());
 
         PostSearchCondition condition = conditionCaptor.getValue();
         org.assertj.core.api.Assertions.assertThat(condition.jobRoles())
                 .containsExactly("PLANNING", "DESIGN");
         org.assertj.core.api.Assertions.assertThat(condition.careerYears())
                 .containsExactly("YEAR_3");
+        org.assertj.core.api.Assertions.assertThat(condition.order()).isEqualTo(PostOrder.POPULAR);
+    }
+
+    @Test
+    void 게시글_상세_조회는_좋아요_여부와_댓글_작성자_메타를_반환한다() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID commentAuthorId = UUID.randomUUID();
+        CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "ogu");
+        PostDetailResponse response =
+                new PostDetailResponse(
+                        1L,
+                        new PostDetailResponse.AuthorInfo(
+                                userId.toString(), "ogu", "DEVELOPMENT", "YEAR_3"),
+                        "면접에서 계속 떨어져서 점점 자신감이 사라져요.",
+                        "COMFORT_ME",
+                        new PostDetailResponse.EmotionInfo("ANXIETY", "불안"),
+                        new PostDetailResponse.MonsterInfo("ANXIETY_MONSTER", 30, 30, "ALIVE"),
+                        3,
+                        true,
+                        1,
+                        List.of(
+                                new PostDetailResponse.CommentInfo(
+                                        10L,
+                                        commentAuthorId.toString(),
+                                        "helper",
+                                        "PLANNING",
+                                        "YEAR_1",
+                                        "힘내세요!",
+                                        2,
+                                        false,
+                                        LocalDateTime.of(2026, 5, 20, 22, 30))),
+                        LocalDateTime.of(2026, 5, 20, 22, 0));
+
+        given(postService.getPostDetail(userId, 1L)).willReturn(response);
+
+        mockMvc.perform(
+                        get("/api/posts/{postId}", 1L)
+                                .with(
+                                        authentication(
+                                                new UsernamePasswordAuthenticationToken(
+                                                        principal, null, List.of()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.likedByMe").value(true))
+                .andExpect(
+                        jsonPath("$.data.comments[0].authorId").value(commentAuthorId.toString()))
+                .andExpect(jsonPath("$.data.comments[0].jobRole").value("PLANNING"))
+                .andExpect(jsonPath("$.data.comments[0].careerYear").value("YEAR_1"))
+                .andExpect(jsonPath("$.data.comments[0].likedByMe").value(false));
+
+        verify(postService).getPostDetail(userId, 1L);
     }
 
     @Test

--- a/src/test/java/com/ddd/webbb/user/interfaces/UserMeControllerTest.java
+++ b/src/test/java/com/ddd/webbb/user/interfaces/UserMeControllerTest.java
@@ -1,0 +1,105 @@
+package com.ddd.webbb.user.interfaces;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ddd.webbb.global.auth.CustomOAuth2UserService;
+import com.ddd.webbb.global.auth.JwtAuthFilter;
+import com.ddd.webbb.global.auth.JwtAuthenticationEntryPoint;
+import com.ddd.webbb.global.auth.JwtProvider;
+import com.ddd.webbb.global.auth.OAuth2LoginFailureHandler;
+import com.ddd.webbb.global.auth.OAuth2LoginSuccessHandler;
+import com.ddd.webbb.global.auth.RedisOAuth2AuthorizationRequestRepository;
+import com.ddd.webbb.global.config.SecurityConfig;
+import com.ddd.webbb.global.security.CustomUserPrincipal;
+import com.ddd.webbb.user.application.UserService;
+import com.ddd.webbb.user.domain.User;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class, JwtAuthenticationEntryPoint.class})
+@ActiveProfiles("test")
+class UserMeControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private UserService userService;
+    @MockitoBean private JwtProvider jwtProvider;
+    @MockitoBean private CustomOAuth2UserService customOAuth2UserService;
+    @MockitoBean private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    @MockitoBean private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    @MockitoBean private RedisOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+    @Test
+    @DisplayName("GET /api/users/me 는 인증 사용자의 정보를 반환한다")
+    void getMe_returnsAuthenticatedUser() throws Exception {
+        UUID publicId = UUID.randomUUID();
+        CustomUserPrincipal principal = new CustomUserPrincipal(publicId, "ogu@test.com", "ogu");
+        User user = User.createOAuthUser("ogu@test.com", "ogu", "DEVELOPMENT", "YEAR_3");
+
+        given(userService.getUserEntity(eq(publicId))).willReturn(user);
+
+        mockMvc.perform(
+                        get("/api/users/me")
+                                .with(
+                                        authentication(
+                                                new UsernamePasswordAuthenticationToken(
+                                                        principal, null, List.of()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(user.getPublicId().toString()))
+                .andExpect(jsonPath("$.data.email").value("ogu@test.com"))
+                .andExpect(jsonPath("$.data.nickname").value("ogu"))
+                .andExpect(jsonPath("$.data.jobType").value("DEVELOPMENT"))
+                .andExpect(jsonPath("$.data.careerLevel").value("YEAR_3"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/users/me/profile 는 인증 사용자의 프로필을 수정한다")
+    void updateMyProfile_updatesAuthenticatedUser() throws Exception {
+        UUID publicId = UUID.randomUUID();
+        CustomUserPrincipal principal = new CustomUserPrincipal(publicId, "ogu@test.com", "ogu");
+        User updatedUser = User.createOAuthUser("ogu@test.com", "newogu", "PLANNING", "YEAR_5");
+
+        given(userService.updateProfile(eq(publicId), eq("newogu"), eq("PLANNING"), eq("YEAR_5")))
+                .willReturn(updatedUser);
+
+        mockMvc.perform(
+                        patch("/api/users/me/profile")
+                                .with(
+                                        authentication(
+                                                new UsernamePasswordAuthenticationToken(
+                                                        principal, null, List.of())))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                    {
+                      "nickname": "newogu",
+                      "jobType": "PLANNING",
+                      "careerLevel": "YEAR_5"
+                    }
+                    """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.email").value("ogu@test.com"))
+                .andExpect(jsonPath("$.data.nickname").value("newogu"))
+                .andExpect(jsonPath("$.data.jobType").value("PLANNING"))
+                .andExpect(jsonPath("$.data.careerLevel").value("YEAR_5"));
+    }
+}


### PR DESCRIPTION
## PR 제목(내용 요약)
스텁으로 남아 있던 사용자/좋아요 API를 실제 서비스에 연결하고, 게시글 조회 응답을 프론트 요구사항에 맞게 보강했습니다.

## 📌 변경 내용 & 이유
- `GET /api/users/me`, `PATCH /api/users/me/profile`, `POST /api/posts/{postId}/likes`, `DELETE /api/posts/{postId}/likes/me`를 스텁 응답에서 실제 서비스 로직으로 전환했습니다.
- 게시글 목록/상세 조회에 `likedByMe`를 추가해 로그인 사용자가 본인의 공감 여부를 바로 확인할 수 있게 했습니다.
- `GET /api/posts/{postId}`의 댓글 응답에 `authorId`, `jobRole`, `careerYear`, `likeCount`, `likedByMe`를 포함해 내 댓글 여부와 작성자 메타를 함께 사용할 수 있게 했습니다.
- 게시글 목록 조회에 `order=LATEST|POPULAR`를 추가하고, 인기순에서도 기존 `cursor=마지막 postId` 방식이 유지되도록 커서 기준을 보강했습니다.
- `PostQueryRepository`를 추가해 조회 포트를 분리했고, 댓글 상세 조회는 fetch join 기반으로 정리했습니다.

## 📸 스크린샷 (선택)
UI 변경 없음

## 🧪 테스트 방법 (선택)
- `./gradlew spotlessApply`
- `./gradlew compileJava`
- `./gradlew compileTestJava`
- `./gradlew test -x :poc:allkite:test --tests '*PostServiceTest' --tests '*PostControllerTest' --tests '*PostRepositoryImplTest' --tests '*PostLikeServiceTest' --tests '*LikeControllerTest' --tests '*UserMeControllerTest' --tests '*CommentServiceTest' --tests '*SecurityEndpointTest'`

## 📢 논의하고 싶은 내용
- 인기순 커서는 요청 파라미터를 기존 `postId` 하나로 유지하면서, 기준 게시글의 `likeCount`를 함께 조회하는 방식으로 맞췄습니다. 추후 정렬 기준이 더 늘어나면 커서 포맷을 별도로 확장하는 쪽이 더 나을지 의견 부탁드립니다.

## ✅ 체크리스트
- [x] 엔티티 스키마 변경 없음

## 🧩 관련 이슈
- 없음