### PR TITLE
fix(comment): 댓글 작성 시 몬스터 HP 감소량 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 src/main/generated/
 
 .codex/
+docs/superpowers/

--- a/src/main/java/com/ddd/webbb/comment/application/CommentService.java
+++ b/src/main/java/com/ddd/webbb/comment/application/CommentService.java
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CommentService {
 
-    private static final int COMMENT_HP_DELTA = 1;
+    private static final int COMMENT_HP_DELTA = 3;
 
     private final CommentRepository commentRepository;
     private final CommentQueryRepository commentQueryRepository;

--- a/src/test/java/com/ddd/webbb/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/ddd/webbb/comment/application/CommentServiceTest.java
@@ -15,7 +15,10 @@ import com.ddd.webbb.config.TestRedisConfig;
 import com.ddd.webbb.emotion.domain.EmotionType;
 import com.ddd.webbb.global.common.exception.AppException;
 import com.ddd.webbb.global.common.exception.ErrorCode;
+import com.ddd.webbb.monster.domain.HpActionType;
 import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.monster.domain.MonsterHpLog;
+import com.ddd.webbb.monster.domain.MonsterHpLogRepository;
 import com.ddd.webbb.monster.domain.MonsterRepository;
 import com.ddd.webbb.post.domain.CommentTone;
 import com.ddd.webbb.post.domain.Post;
@@ -41,6 +44,7 @@ class CommentServiceTest {
     @Autowired private UserRepository userRepository;
     @Autowired private PostRepository postRepository;
     @Autowired private MonsterRepository monsterRepository;
+    @Autowired private MonsterHpLogRepository monsterHpLogRepository;
     @Autowired private BoardCategoryRepository boardCategoryRepository;
 
     private User user;
@@ -79,7 +83,12 @@ class CommentServiceTest {
             assertThat(response.postId()).isEqualTo(post.getId());
             assertThat(response.parentCommentId()).isNull();
             assertThat(response.content()).isEqualTo("힘내세요!");
-            assertThat(response.monster().hp()).isEqualTo(29);
+            MonsterHpLog hpLog = monsterHpLogRepository.findAll().get(0);
+            assertThat(hpLog.getActionType()).isEqualTo(HpActionType.COMMENT);
+            assertThat(hpLog.getHpDelta()).isEqualTo(3);
+            assertThat(hpLog.getBeforeHp()).isEqualTo(30);
+            assertThat(hpLog.getAfterHp()).isEqualTo(27);
+            assertThat(response.monster().hp()).isEqualTo(27);
             assertThat(post.getCommentCount()).isEqualTo(1);
         }
 
@@ -97,6 +106,7 @@ class CommentServiceTest {
 
             // Then
             assertThat(response.parentCommentId()).isEqualTo(parent.getId());
+            assertThat(response.monster().hp()).isEqualTo(27);
         }
 
         @Test

--- a/src/test/java/com/ddd/webbb/comment/interfaces/CommentControllerTest.java
+++ b/src/test/java/com/ddd/webbb/comment/interfaces/CommentControllerTest.java
@@ -113,7 +113,7 @@ class CommentControllerTest {
                             1L,
                             null,
                             "힘내세요!",
-                            new CommentResponse.MonsterInfo(29, 30, "ALIVE"),
+                            new CommentResponse.MonsterInfo(27, 30, "ALIVE"),
                             LocalDateTime.of(2026, 4, 27, 21, 30));
 
             given(commentService.addComment(eq(userId), eq(1L), any(CommentCreateRequest.class)))
@@ -133,7 +133,7 @@ class CommentControllerTest {
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.commentId").value(1L))
-                    .andExpect(jsonPath("$.data.monster.hp").value(29));
+                    .andExpect(jsonPath("$.data.monster.hp").value(27));
         }
 
         @Test


### PR DESCRIPTION
## PR 제목(내용 요약)
댓글과 대댓글 작성 시 몬스터 HP 감소량을 1에서 3으로 변경했습니다.

## 📌 변경 내용 & 이유
- 댓글 작성 시 적용되는 `COMMENT_HP_DELTA`를 `1`에서 `3`으로 변경했습니다.
- 루트 댓글과 대댓글 모두 작성 건당 몬스터 HP가 3 감소하도록 서비스 테스트를 보강했습니다.
- `monster_hp_log`에 `COMMENT`, `hpDelta=3`, 변경 전·후 HP가 정확히 저장되는지 검증했습니다.
- 댓글 작성 API 응답의 몬스터 HP 기대값을 새 정책에 맞게 수정했습니다.
- 댓글 공감 시 HP가 1 감소하는 기존 동작과 삭제·공감 취소 시 HP를 복구하지 않는 정책은 유지합니다.
- 로컬 개발 계획 산출물이 저장소에 포함되지 않도록 `docs/superpowers/`를 Git 추적 대상에서 제외했습니다.

## 📸 스크린샷 (선택)
UI 변경 없음

## 🧪 테스트 방법 (선택)
- `./gradlew :test --tests 'com.ddd.webbb.comment.application.CommentServiceTest$AddComment' --rerun-tasks`
- `./gradlew :test --tests 'com.ddd.webbb.comment.*' --rerun-tasks`
- `./gradlew spotlessCheck test`

## 📢 논의하고 싶은 내용
- 없음

## ✅ 체크리스트
- [x] 엔티티 스키마 변경 없음

## 🧩 관련 이슈
- Close #99
