### PR TITLE
feat(notification): 실시간 알림 기능 구현 (SSE)

### DIFF
--- a/src/main/java/com/ddd/webbb/comment/application/CommentService.java
+++ b/src/main/java/com/ddd/webbb/comment/application/CommentService.java
@@ -12,6 +12,7 @@ import com.ddd.webbb.global.common.exception.ErrorCode;
 import com.ddd.webbb.monster.application.MonsterService;
 import com.ddd.webbb.monster.domain.HpActionType;
 import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.notification.domain.event.CommentNotificationEvent;
 import com.ddd.webbb.post.application.PostService;
 import com.ddd.webbb.post.domain.Post;
 import com.ddd.webbb.user.application.UserService;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,18 +37,21 @@ public class CommentService {
     private final PostService postService;
     private final UserService userService;
     private final MonsterService monsterService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public CommentService(
             CommentRepository commentRepository,
             CommentQueryRepository commentQueryRepository,
             @Lazy PostService postService,
             UserService userService,
-            MonsterService monsterService) {
+            MonsterService monsterService,
+            ApplicationEventPublisher eventPublisher) {
         this.commentRepository = commentRepository;
         this.commentQueryRepository = commentQueryRepository;
         this.postService = postService;
         this.userService = userService;
         this.monsterService = monsterService;
+        this.eventPublisher = eventPublisher;
     }
 
     public List<Comment> findCommentsByPost(Long postId) {
@@ -110,6 +115,7 @@ public class CommentService {
         monsterService.decreaseMonsterHp(
                 monster, user, post, comment, HpActionType.COMMENT, COMMENT_HP_DELTA);
 
+        eventPublisher.publishEvent(new CommentNotificationEvent(post.getUser(), user, post));
         return CommentResponse.of(comment, monster);
     }
 

--- a/src/main/java/com/ddd/webbb/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ddd/webbb/global/common/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     OAUTH_ALREADY_LINKED(HttpStatus.CONFLICT, "해당 OAuth 계정은 다른 사용자에게 이미 연동되어 있습니다."),
     OAUTH_PROVIDER_NOT_LINKED(HttpStatus.NOT_FOUND, "해당 OAuth 제공자가 연동되어 있지 않습니다."),
     CANNOT_UNLINK_LAST_AUTH(HttpStatus.BAD_REQUEST, "마지막 인증 수단은 해제할 수 없습니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/ddd/webbb/global/config/AsyncConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/AsyncConfig.java
@@ -1,0 +1,8 @@
+package com.ddd.webbb.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {}

--- a/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
@@ -179,6 +179,15 @@ public class SwaggerConfig {
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/me/comments");
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/me/monster-stats");
 
+        put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/notifications/subscribe");
+        put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/notifications");
+        put(
+                statuses,
+                ApiImplementationStatus.LIVE,
+                "PATCH",
+                "/api/notifications/{notificationId}/read");
+        put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/notifications/unread");
+
         return Map.copyOf(statuses);
     }
 

--- a/src/main/java/com/ddd/webbb/monster/application/MonsterService.java
+++ b/src/main/java/com/ddd/webbb/monster/application/MonsterService.java
@@ -9,9 +9,12 @@ import com.ddd.webbb.monster.domain.Monster;
 import com.ddd.webbb.monster.domain.MonsterHpLog;
 import com.ddd.webbb.monster.domain.MonsterHpLogRepository;
 import com.ddd.webbb.monster.domain.MonsterRepository;
+import com.ddd.webbb.monster.domain.MonsterStatus;
+import com.ddd.webbb.notification.domain.event.MonsterDefeatedNotificationEvent;
 import com.ddd.webbb.post.domain.Post;
 import com.ddd.webbb.user.domain.User;
 import java.util.List;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,11 +28,15 @@ public class MonsterService {
 
     private final MonsterRepository monsterRepository;
     private final MonsterHpLogRepository monsterHpLogRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public MonsterService(
-            MonsterRepository monsterRepository, MonsterHpLogRepository monsterHpLogRepository) {
+            MonsterRepository monsterRepository,
+            MonsterHpLogRepository monsterHpLogRepository,
+            ApplicationEventPublisher eventPublisher) {
         this.monsterRepository = monsterRepository;
         this.monsterHpLogRepository = monsterHpLogRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     public Monster getMonsterByPostId(Long postId) {
@@ -71,6 +78,10 @@ public class MonsterService {
         monsterHpLogRepository.save(
                 MonsterHpLog.create(
                         monster, user, post, comment, actionType, delta, beforeHp, afterHp));
+
+        if (monster.getStatus() == MonsterStatus.DEAD && beforeHp > 0) {
+            eventPublisher.publishEvent(new MonsterDefeatedNotificationEvent(post.getUser(), post));
+        }
     }
 
     @Transactional

--- a/src/main/java/com/ddd/webbb/notification/application/NotificationService.java
+++ b/src/main/java/com/ddd/webbb/notification/application/NotificationService.java
@@ -1,0 +1,54 @@
+package com.ddd.webbb.notification.application;
+
+import com.ddd.webbb.global.common.exception.AppException;
+import com.ddd.webbb.global.common.exception.ErrorCode;
+import com.ddd.webbb.notification.domain.Notification;
+import com.ddd.webbb.notification.domain.NotificationRepository;
+import com.ddd.webbb.notification.interfaces.dto.NotificationResponse;
+import com.ddd.webbb.notification.interfaces.dto.UnreadNotificationResponse;
+import com.ddd.webbb.user.application.UserService;
+import com.ddd.webbb.user.domain.User;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserService userService;
+
+    public NotificationService(
+            NotificationRepository notificationRepository, UserService userService) {
+        this.notificationRepository = notificationRepository;
+        this.userService = userService;
+    }
+
+    public List<NotificationResponse> getNotifications(UUID userPublicId) {
+        User user = userService.getUserEntity(userPublicId);
+        return notificationRepository.findByReceiverOrderByCreatedAtDesc(user).stream()
+                .map(NotificationResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public void markAsRead(UUID userPublicId, Long notificationId) {
+        User user = userService.getUserEntity(userPublicId);
+        Notification notification =
+                notificationRepository
+                        .findById(notificationId)
+                        .orElseThrow(() -> new AppException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        if (!notification.getReceiver().getId().equals(user.getId())) {
+            throw new AppException(ErrorCode.FORBIDDEN);
+        }
+        notification.markAsRead();
+    }
+
+    public UnreadNotificationResponse hasUnread(UUID userPublicId) {
+        User user = userService.getUserEntity(userPublicId);
+        return new UnreadNotificationResponse(
+                notificationRepository.existsByReceiverAndIsReadFalse(user));
+    }
+}

--- a/src/main/java/com/ddd/webbb/notification/domain/Notification.java
+++ b/src/main/java/com/ddd/webbb/notification/domain/Notification.java
@@ -1,0 +1,83 @@
+package com.ddd.webbb.notification.domain;
+
+import com.ddd.webbb.global.common.entity.BaseCreatedEntity;
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "notifications")
+public class Notification extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_id")
+    private User actor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private boolean isRead = false;
+
+    protected Notification() {}
+
+    public static Notification of(User receiver, User actor, Post post, NotificationType type) {
+        Notification notification = new Notification();
+        notification.receiver = receiver;
+        notification.actor = actor;
+        notification.post = post;
+        notification.type = type;
+        return notification;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getReceiver() {
+        return receiver;
+    }
+
+    public User getActor() {
+        return actor;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public NotificationType getType() {
+        return type;
+    }
+
+    public boolean isRead() {
+        return isRead;
+    }
+}

--- a/src/main/java/com/ddd/webbb/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/ddd/webbb/notification/domain/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.ddd.webbb.notification.domain;
+
+import com.ddd.webbb.user.domain.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByReceiverOrderByCreatedAtDesc(User receiver);
+
+    boolean existsByReceiverAndIsReadFalse(User receiver);
+}

--- a/src/main/java/com/ddd/webbb/notification/domain/NotificationType.java
+++ b/src/main/java/com/ddd/webbb/notification/domain/NotificationType.java
@@ -1,0 +1,7 @@
+package com.ddd.webbb.notification.domain;
+
+public enum NotificationType {
+    COMMENT,
+    POST_LIKE,
+    MONSTER_DEFEATED
+}

--- a/src/main/java/com/ddd/webbb/notification/domain/event/CommentNotificationEvent.java
+++ b/src/main/java/com/ddd/webbb/notification/domain/event/CommentNotificationEvent.java
@@ -1,0 +1,6 @@
+package com.ddd.webbb.notification.domain.event;
+
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.user.domain.User;
+
+public record CommentNotificationEvent(User postOwner, User actor, Post post) {}

--- a/src/main/java/com/ddd/webbb/notification/domain/event/MonsterDefeatedNotificationEvent.java
+++ b/src/main/java/com/ddd/webbb/notification/domain/event/MonsterDefeatedNotificationEvent.java
@@ -1,0 +1,6 @@
+package com.ddd.webbb.notification.domain.event;
+
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.user.domain.User;
+
+public record MonsterDefeatedNotificationEvent(User postOwner, Post post) {}

--- a/src/main/java/com/ddd/webbb/notification/domain/event/PostLikeNotificationEvent.java
+++ b/src/main/java/com/ddd/webbb/notification/domain/event/PostLikeNotificationEvent.java
@@ -1,0 +1,6 @@
+package com.ddd.webbb.notification.domain.event;
+
+import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.user.domain.User;
+
+public record PostLikeNotificationEvent(User postOwner, User actor, Post post) {}

--- a/src/main/java/com/ddd/webbb/notification/infrastructure/NotificationEventHandler.java
+++ b/src/main/java/com/ddd/webbb/notification/infrastructure/NotificationEventHandler.java
@@ -1,0 +1,71 @@
+package com.ddd.webbb.notification.infrastructure;
+
+import com.ddd.webbb.notification.domain.Notification;
+import com.ddd.webbb.notification.domain.NotificationRepository;
+import com.ddd.webbb.notification.domain.NotificationType;
+import com.ddd.webbb.notification.domain.event.CommentNotificationEvent;
+import com.ddd.webbb.notification.domain.event.MonsterDefeatedNotificationEvent;
+import com.ddd.webbb.notification.domain.event.PostLikeNotificationEvent;
+import com.ddd.webbb.notification.interfaces.dto.NotificationResponse;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+public class NotificationEventHandler {
+
+    private final NotificationRepository notificationRepository;
+    private final SseEmitterManager sseEmitterManager;
+
+    public NotificationEventHandler(
+            NotificationRepository notificationRepository, SseEmitterManager sseEmitterManager) {
+        this.notificationRepository = notificationRepository;
+        this.sseEmitterManager = sseEmitterManager;
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCommentNotification(CommentNotificationEvent event) {
+        if (event.actor().getId().equals(event.postOwner().getId())) {
+            return;
+        }
+        Notification saved =
+                notificationRepository.save(
+                        Notification.of(
+                                event.postOwner(),
+                                event.actor(),
+                                event.post(),
+                                NotificationType.COMMENT));
+        sseEmitterManager.send(event.postOwner().getId(), NotificationResponse.from(saved));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePostLikeNotification(PostLikeNotificationEvent event) {
+        if (event.actor().getId().equals(event.postOwner().getId())) {
+            return;
+        }
+        Notification saved =
+                notificationRepository.save(
+                        Notification.of(
+                                event.postOwner(),
+                                event.actor(),
+                                event.post(),
+                                NotificationType.POST_LIKE));
+        sseEmitterManager.send(event.postOwner().getId(), NotificationResponse.from(saved));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMonsterDefeatedNotification(MonsterDefeatedNotificationEvent event) {
+        Notification saved =
+                notificationRepository.save(
+                        Notification.of(
+                                event.postOwner(),
+                                null,
+                                event.post(),
+                                NotificationType.MONSTER_DEFEATED));
+        sseEmitterManager.send(event.postOwner().getId(), NotificationResponse.from(saved));
+    }
+}

--- a/src/main/java/com/ddd/webbb/notification/infrastructure/SseEmitterManager.java
+++ b/src/main/java/com/ddd/webbb/notification/infrastructure/SseEmitterManager.java
@@ -1,0 +1,42 @@
+package com.ddd.webbb.notification.infrastructure;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class SseEmitterManager {
+
+    private static final long TIMEOUT_MS = 30 * 60 * 1000L;
+
+    private final ConcurrentHashMap<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = new SseEmitter(TIMEOUT_MS);
+        emitters.put(userId, emitter);
+        emitter.onCompletion(() -> emitters.remove(userId));
+        emitter.onTimeout(() -> emitters.remove(userId));
+        emitter.onError(e -> emitters.remove(userId));
+
+        // nginx 프록시 버퍼링 방지용 더미 이벤트
+        try {
+            emitter.send(SseEmitter.event().name("connect").data("connected"));
+        } catch (IOException e) {
+            emitters.remove(userId);
+        }
+        return emitter;
+    }
+
+    public void send(Long userId, Object data) {
+        SseEmitter emitter = emitters.get(userId);
+        if (emitter == null) {
+            return;
+        }
+        try {
+            emitter.send(SseEmitter.event().name("notification").data(data));
+        } catch (IOException e) {
+            emitters.remove(userId);
+        }
+    }
+}

--- a/src/main/java/com/ddd/webbb/notification/interfaces/NotificationController.java
+++ b/src/main/java/com/ddd/webbb/notification/interfaces/NotificationController.java
@@ -1,0 +1,295 @@
+package com.ddd.webbb.notification.interfaces;
+
+import com.ddd.webbb.global.common.response.ApiResponse;
+import com.ddd.webbb.global.security.CustomUserPrincipal;
+import com.ddd.webbb.notification.application.NotificationService;
+import com.ddd.webbb.notification.infrastructure.SseEmitterManager;
+import com.ddd.webbb.notification.interfaces.dto.NotificationResponse;
+import com.ddd.webbb.notification.interfaces.dto.UnreadNotificationResponse;
+import com.ddd.webbb.user.application.UserService;
+import com.ddd.webbb.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "Notification", description = "알림 API")
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final SseEmitterManager sseEmitterManager;
+    private final UserService userService;
+
+    public NotificationController(
+            NotificationService notificationService,
+            SseEmitterManager sseEmitterManager,
+            UserService userService) {
+        this.notificationService = notificationService;
+        this.sseEmitterManager = sseEmitterManager;
+        this.userService = userService;
+    }
+
+    @Operation(
+            summary = "SSE 구독",
+            description =
+                    "실시간 알림 수신을 위한 SSE(Server-Sent Events) 연결을 맺습니다.\n\n"
+                            + "웹 페이지 진입 시 1회 호출하면 서버와 연결이 유지되며, 새 알림이 발생하는 즉시 클라이언트로 푸시됩니다.\n\n"
+                            + "연결 직후 더미 이벤트가 1회 전송됩니다:\n"
+                            + "```\nevent: connect\ndata: connected\n```\n\n"
+                            + "이후 알림 발생 시 아래 형식으로 수신됩니다:\n"
+                            + "```\nevent: notification\ndata: {\"id\":1,\"type\":\"COMMENT\",...}\n```\n\n"
+                            + "**type 값별 메시지:**\n"
+                            + "- `COMMENT`: {actorNickname} 님이 내 글에 댓글을 달았어요.\n"
+                            + "- `POST_LIKE`: {actorNickname} 님이 내 글에 공감했어요.\n"
+                            + "- `MONSTER_DEFEATED`: 내 글의 몬스터 처치를 완료했어요. (actorNickname은 null)\n\n"
+                            + "**주의:** 브라우저 기본 `EventSource`는 Authorization 헤더를 지원하지 않으므로 "
+                            + "`@microsoft/fetch-event-source` 라이브러리 사용을 권장합니다.\n\n"
+                            + "연결 timeout은 30분이며, 연결이 끊기면 재연결이 필요합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "SSE 연결 성공 (text/event-stream)",
+                content =
+                        @Content(
+                                mediaType = MediaType.TEXT_EVENT_STREAM_VALUE,
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        event: connect
+                                                        data: connected
+
+                                                        event: notification
+                                                        data: {"id":1,"type":"COMMENT","actorNickname":"DDD","postId":123,"isRead":false,"createdAt":"2026-06-23T20:00:00"}
+
+                                                        event: notification
+                                                        data: {"id":2,"type":"MONSTER_DEFEATED","actorNickname":null,"postId":123,"isRead":false,"createdAt":"2026-06-23T20:01:00"}
+                                                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "인증 실패 또는 Access Token 누락",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        {
+                                                          "success": false,
+                                                          "message": "인증이 필요합니다.",
+                                                          "timestamp": "2026-06-23T20:00:00"
+                                                        }
+                                                        """)))
+    })
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        User user = userService.getUserEntity(principal.publicId());
+        return sseEmitterManager.subscribe(user.getId());
+    }
+
+    @Operation(
+            summary = "알림 목록 조회",
+            description =
+                    "로그인한 사용자의 알림 목록을 최신순으로 반환합니다.\n\n"
+                            + "페이지 로드 시 초기 데이터를 가져오는 용도로 사용합니다. "
+                            + "이후 실시간 알림은 SSE를 통해 수신됩니다.\n\n"
+                            + "isRead가 false인 항목이 읽지 않은 알림입니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "알림 목록 조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        {
+                                                          "success": true,
+                                                          "message": "알림 목록을 조회했습니다.",
+                                                          "data": [
+                                                            {
+                                                              "id": 3,
+                                                              "type": "MONSTER_DEFEATED",
+                                                              "actorNickname": null,
+                                                              "postId": 123,
+                                                              "isRead": false,
+                                                              "createdAt": "2026-06-23T20:01:00"
+                                                            },
+                                                            {
+                                                              "id": 2,
+                                                              "type": "POST_LIKE",
+                                                              "actorNickname": "maru",
+                                                              "postId": 123,
+                                                              "isRead": true,
+                                                              "createdAt": "2026-06-23T19:30:00"
+                                                            },
+                                                            {
+                                                              "id": 1,
+                                                              "type": "COMMENT",
+                                                              "actorNickname": "DDD",
+                                                              "postId": 123,
+                                                              "isRead": true,
+                                                              "createdAt": "2026-06-23T19:00:00"
+                                                            }
+                                                          ],
+                                                          "timestamp": "2026-06-23T20:05:00"
+                                                        }
+                                                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "인증 실패 또는 Access Token 누락",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        {
+                                                          "success": false,
+                                                          "message": "인증이 필요합니다.",
+                                                          "timestamp": "2026-06-23T20:05:00"
+                                                        }
+                                                        """)))
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NotificationResponse>>> readNotifications(
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        List<NotificationResponse> notifications =
+                notificationService.getNotifications(principal.publicId());
+        return ResponseEntity.ok(ApiResponse.ok("알림 목록을 조회했습니다.", notifications));
+    }
+
+    @Operation(
+            summary = "알림 읽음 처리",
+            description =
+                    "알림을 클릭해 해당 게시글로 이동할 때 호출합니다.\n\n" + "isRead가 이미 true인 알림에 중복 호출해도 무방합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "읽음 처리 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        {
+                                                          "success": true,
+                                                          "message": "알림을 읽음 처리했습니다.",
+                                                          "timestamp": "2026-06-23T20:05:00"
+                                                        }
+                                                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "인증 실패 또는 Access Token 누락",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        {
+                                                          "success": false,
+                                                          "message": "인증이 필요합니다.",
+                                                          "timestamp": "2026-06-23T20:05:00"
+                                                        }
+                                                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "본인 알림이 아님",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        {
+                                                          "success": false,
+                                                          "message": "권한이 없습니다.",
+                                                          "timestamp": "2026-06-23T20:05:00"
+                                                        }
+                                                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "존재하지 않는 알림",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        {
+                                                          "success": false,
+                                                          "message": "존재하지 않는 알림입니다.",
+                                                          "timestamp": "2026-06-23T20:05:00"
+                                                        }
+                                                        """)))
+    })
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<ApiResponse<Void>> updateNotificationRead(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long notificationId) {
+        notificationService.markAsRead(principal.publicId(), notificationId);
+        return ResponseEntity.ok(ApiResponse.ok("알림을 읽음 처리했습니다.", null));
+    }
+
+    @Operation(
+            summary = "미읽음 알림 여부 조회",
+            description =
+                    "읽지 않은 알림이 하나라도 있으면 true를 반환합니다.\n\n"
+                            + "페이지 최초 로드 시 종 아이콘의 빨간 뱃지 표시 여부를 결정하는 데 사용합니다. "
+                            + "이후 실시간 뱃지 갱신은 SSE 이벤트 수신으로 처리합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "미읽음 여부 조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        {
+                                                          "success": true,
+                                                          "message": "요청이 성공했습니다.",
+                                                          "data": { "hasUnread": true },
+                                                          "timestamp": "2026-06-23T20:05:00"
+                                                        }
+                                                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "인증 실패 또는 Access Token 누락",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                                                        {
+                                                          "success": false,
+                                                          "message": "인증이 필요합니다.",
+                                                          "timestamp": "2026-06-23T20:05:00"
+                                                        }
+                                                        """)))
+    })
+    @GetMapping("/unread")
+    public ResponseEntity<ApiResponse<UnreadNotificationResponse>> readUnreadStatus(
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        UnreadNotificationResponse response = notificationService.hasUnread(principal.publicId());
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+}

--- a/src/main/java/com/ddd/webbb/notification/interfaces/dto/NotificationResponse.java
+++ b/src/main/java/com/ddd/webbb/notification/interfaces/dto/NotificationResponse.java
@@ -1,0 +1,24 @@
+package com.ddd.webbb.notification.interfaces.dto;
+
+import com.ddd.webbb.notification.domain.Notification;
+import com.ddd.webbb.notification.domain.NotificationType;
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long id,
+        NotificationType type,
+        String actorNickname,
+        Long postId,
+        boolean isRead,
+        LocalDateTime createdAt) {
+
+    public static NotificationResponse from(Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getType(),
+                notification.getActor() != null ? notification.getActor().getNickname() : null,
+                notification.getPost().getId(),
+                notification.isRead(),
+                notification.getCreatedAt());
+    }
+}

--- a/src/main/java/com/ddd/webbb/notification/interfaces/dto/UnreadNotificationResponse.java
+++ b/src/main/java/com/ddd/webbb/notification/interfaces/dto/UnreadNotificationResponse.java
@@ -1,0 +1,3 @@
+package com.ddd.webbb.notification.interfaces.dto;
+
+public record UnreadNotificationResponse(boolean hasUnread) {}

--- a/src/main/java/com/ddd/webbb/post/application/PostLikeService.java
+++ b/src/main/java/com/ddd/webbb/post/application/PostLikeService.java
@@ -5,6 +5,7 @@ import com.ddd.webbb.global.common.exception.ErrorCode;
 import com.ddd.webbb.monster.application.MonsterService;
 import com.ddd.webbb.monster.domain.HpActionType;
 import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.notification.domain.event.PostLikeNotificationEvent;
 import com.ddd.webbb.post.domain.Post;
 import com.ddd.webbb.post.domain.PostLike;
 import com.ddd.webbb.post.domain.PostLikeRepository;
@@ -13,6 +14,7 @@ import com.ddd.webbb.post.interfaces.dto.LikeResponse;
 import com.ddd.webbb.user.application.UserService;
 import com.ddd.webbb.user.domain.User;
 import java.util.UUID;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,16 +29,19 @@ public class PostLikeService {
     private final PostRepository postRepository;
     private final UserService userService;
     private final MonsterService monsterService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public PostLikeService(
             PostLikeRepository postLikeRepository,
             PostRepository postRepository,
             UserService userService,
-            MonsterService monsterService) {
+            MonsterService monsterService,
+            ApplicationEventPublisher eventPublisher) {
         this.postLikeRepository = postLikeRepository;
         this.postRepository = postRepository;
         this.userService = userService;
         this.monsterService = monsterService;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional
@@ -55,6 +60,7 @@ public class PostLikeService {
         monsterService.decreaseMonsterHp(
                 monster, user, post, null, HpActionType.POST_LIKE, POST_LIKE_HP_DELTA);
 
+        eventPublisher.publishEvent(new PostLikeNotificationEvent(post.getUser(), user, post));
         return LikeResponse.of(post, monster);
     }
 

--- a/src/main/resources/db/migration/V3__create_notifications_table.sql
+++ b/src/main/resources/db/migration/V3__create_notifications_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE notifications (
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    receiver_id BIGINT      NOT NULL,
+    actor_id    BIGINT      NULL,
+    post_id     BIGINT      NOT NULL,
+    type        VARCHAR(30) NOT NULL,
+    is_read     BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at  DATETIME(6) NOT NULL,
+    FOREIGN KEY (receiver_id) REFERENCES users (id),
+    FOREIGN KEY (actor_id) REFERENCES users (id),
+    FOREIGN KEY (post_id) REFERENCES post (id),
+    INDEX idx_notifications_receiver (receiver_id),
+    INDEX idx_notifications_receiver_unread (receiver_id, is_read)
+);

--- a/src/test/java/com/ddd/webbb/global/config/SwaggerConfigTest.java
+++ b/src/test/java/com/ddd/webbb/global/config/SwaggerConfigTest.java
@@ -8,6 +8,7 @@ import com.ddd.webbb.auth.interfaces.dto.EmailLoginRequest;
 import com.ddd.webbb.comment.interfaces.CommentController;
 import com.ddd.webbb.comment.interfaces.CommentLikeController;
 import com.ddd.webbb.mypage.interfaces.MyPageController;
+import com.ddd.webbb.notification.interfaces.NotificationController;
 import com.ddd.webbb.post.interfaces.LikeController;
 import com.ddd.webbb.post.interfaces.PostController;
 import com.ddd.webbb.user.interfaces.UserController;
@@ -95,6 +96,7 @@ class SwaggerConfigTest {
                 CommentLikeController.class,
                 LikeController.class,
                 MyPageController.class,
+                NotificationController.class,
                 PostController.class,
                 UserController.class);
     }

--- a/src/test/java/com/ddd/webbb/monster/application/MonsterServiceTest.java
+++ b/src/test/java/com/ddd/webbb/monster/application/MonsterServiceTest.java
@@ -15,6 +15,7 @@ import com.ddd.webbb.post.domain.Post;
 import com.ddd.webbb.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
 
 class MonsterServiceTest {
 
@@ -26,7 +27,9 @@ class MonsterServiceTest {
     void setUp() {
         monsterRepository = mock(MonsterRepository.class);
         monsterHpLogRepository = mock(MonsterHpLogRepository.class);
-        monsterService = new MonsterService(monsterRepository, monsterHpLogRepository);
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        monsterService =
+                new MonsterService(monsterRepository, monsterHpLogRepository, eventPublisher);
     }
 
     @Test


### PR DESCRIPTION
## PR 제목(내용 요약)
SSE(Server-Sent Events) 기반 실시간 알림 기능을 구현했습니다. 댓글 작성, 게시글 좋아요, 몬스터 처치 완료 시 알림이 발생하며, 알림 목록 조회·읽음 처리·미읽음 뱃지 API를 제공합니다.

## 📌 변경 내용 & 이유

### 신규 도메인
- `Notification` 엔티티 추가 (`receiver`, `actor`, `post`, `type`, `isRead`, `createdAt`)
- `NotificationType` enum 추가 (`COMMENT` / `POST_LIKE` / `MONSTER_DEFEATED`)
- `NotificationRepository` 추가 (목록 최신순 조회, 미읽음 존재 여부)

### SSE 인프라
- `SseEmitterManager` 추가 — 유저 ID별 `SseEmitter` 인메모리 관리 (30분 timeout, ConcurrentHashMap)
- `NotificationEventHandler` 추가 — `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` 조합으로 트랜잭션 커밋 후 DB 저장 → SSE 푸시
- `AsyncConfig` 추가 — `@EnableAsync` 등록

### 이벤트 발행 (기존 서비스 수정)
- `CommentService.addComment()` — `CommentNotificationEvent` 발행
- `PostLikeService.addPostLike()` — `PostLikeNotificationEvent` 발행
- `MonsterService.decreaseMonsterHp()` — 처치 완료(`status == DEAD`) 시 `MonsterDefeatedNotificationEvent` 발행
- 자기 글에 자기가 행동하는 경우 알림 미발행은 핸들러에서 필터링

### API
| Method | URL | 설명 |
|---|---|---|
| GET | `/api/notifications/subscribe` | SSE 구독 (text/event-stream) |
| GET | `/api/notifications` | 알림 목록 조회 (최신순) |
| PATCH | `/api/notifications/{id}/read` | 읽음 처리 (게시글 이동 시 호출) |
| GET | `/api/notifications/unread` | 미읽음 여부 (뱃지용) |

### DB
- `V3__create_notifications_table.sql` 마이그레이션 추가

## 📸 스크린샷 (선택)
UI 변경 없음

## 🧪 테스트 방법 (선택)
```bash
# 전체 테스트
./gradlew test

# 서버 실행 후 Swagger UI에서 수동 검증
# 1. GET /api/notifications/subscribe — SSE 연결 (fetch-event-source 사용)
# 2. 다른 계정으로 댓글 작성 → notification 이벤트 즉시 수신 확인
# 3. GET /api/notifications → 목록 조회
# 4. PATCH /api/notifications/{id}/read → isRead: true 확인
# 5. GET /api/notifications/unread → hasUnread 값 확인
```

## 📢 논의하고 싶은 내용
- `SseEmitterManager`는 단일 서버 기준 인메모리 구현입니다. 스케일아웃 시 Redis Pub/Sub 확장이 필요합니다.
- 웹 프론트에서 브라우저 기본 `EventSource`는 Authorization 헤더 미지원으로, `@microsoft/fetch-event-source` 사용을 권장합니다.

## ✅ 체크리스트
- [x] 엔티티(`@Entity`) 스키마를 변경한 경우 `db/migration/V{N}__*.sql` 파일을 함께 포함했다

## 🧩 관련 이슈
- Close #103