### PR TITLE
feat(mypage): 마이페이지 공감한 글 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
@@ -177,6 +177,7 @@ public class SwaggerConfig {
 
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/me/posts");
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/me/comments");
+        put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/me/liked-posts");
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/me/monster-stats");
 
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/notifications/subscribe");

--- a/src/main/java/com/ddd/webbb/mypage/application/MyPageService.java
+++ b/src/main/java/com/ddd/webbb/mypage/application/MyPageService.java
@@ -9,8 +9,10 @@ import com.ddd.webbb.monster.domain.MonsterStatus;
 import com.ddd.webbb.mypage.domain.MyPageReadRepository;
 import com.ddd.webbb.mypage.interfaces.dto.MonsterStatsResponse;
 import com.ddd.webbb.mypage.interfaces.dto.MyCommentResponse;
+import com.ddd.webbb.mypage.interfaces.dto.MyLikedPostResponse;
 import com.ddd.webbb.mypage.interfaces.dto.MyPostResponse;
 import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostLike;
 import com.ddd.webbb.user.application.UserService;
 import com.ddd.webbb.user.domain.User;
 import java.util.Collections;
@@ -54,6 +56,32 @@ public class MyPageService {
 
         Long nextCursor = hasNext ? posts.get(posts.size() - 1).getId() : null;
         return new MyPostResponse(myPosts, nextCursor);
+    }
+
+    public MyLikedPostResponse getLikedPosts(UUID userPublicId, Long cursor, int size) {
+        validateSize(size);
+        User user = userService.getUserEntity(userPublicId);
+        List<PostLike> fetched = myPageReadRepository.findLikedPosts(user, cursor, size);
+
+        boolean hasNext = fetched.size() > size;
+        List<PostLike> likes = hasNext ? fetched.subList(0, size) : fetched;
+
+        List<Long> postIds = likes.stream().map(pl -> pl.getPost().getId()).toList();
+        Map<Long, Monster> monsterByPostId =
+                myPageReadRepository.findMonstersByPostIds(postIds).stream()
+                        .collect(Collectors.toMap(m -> m.getPost().getId(), m -> m));
+
+        List<MyLikedPostResponse.LikedPost> posts =
+                likes.stream()
+                        .map(
+                                pl ->
+                                        MyLikedPostResponse.LikedPost.of(
+                                                pl.getPost(),
+                                                monsterByPostId.get(pl.getPost().getId())))
+                        .toList();
+
+        Long nextCursor = hasNext ? likes.get(likes.size() - 1).getId() : null;
+        return new MyLikedPostResponse(posts, nextCursor);
     }
 
     public MyCommentResponse getMyComments(UUID userPublicId, Long cursor, int size) {

--- a/src/main/java/com/ddd/webbb/mypage/domain/MyPageReadRepository.java
+++ b/src/main/java/com/ddd/webbb/mypage/domain/MyPageReadRepository.java
@@ -3,6 +3,7 @@ package com.ddd.webbb.mypage.domain;
 import com.ddd.webbb.comment.domain.Comment;
 import com.ddd.webbb.monster.domain.Monster;
 import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostLike;
 import com.ddd.webbb.user.domain.User;
 import java.util.List;
 
@@ -10,6 +11,8 @@ public interface MyPageReadRepository {
     List<Post> findMyPosts(User user, Long cursor, int size);
 
     List<Comment> findMyComments(User user, Long cursor, int size);
+
+    List<PostLike> findLikedPosts(User user, Long cursor, int size);
 
     List<Monster> findMonstersByPostIds(List<Long> postIds);
 

--- a/src/main/java/com/ddd/webbb/mypage/infrastructure/MyPageReadRepositoryImpl.java
+++ b/src/main/java/com/ddd/webbb/mypage/infrastructure/MyPageReadRepositoryImpl.java
@@ -6,8 +6,14 @@ import com.ddd.webbb.monster.domain.Monster;
 import com.ddd.webbb.monster.domain.MonsterRepository;
 import com.ddd.webbb.mypage.domain.MyPageReadRepository;
 import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostLike;
 import com.ddd.webbb.post.domain.PostQueryRepository;
+import com.ddd.webbb.post.domain.QPost;
+import com.ddd.webbb.post.domain.QPostLike;
+import com.ddd.webbb.user.domain.QUser;
 import com.ddd.webbb.user.domain.User;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import org.springframework.stereotype.Repository;
 
@@ -17,14 +23,17 @@ public class MyPageReadRepositoryImpl implements MyPageReadRepository {
     private final PostQueryRepository postQueryRepository;
     private final CommentQueryRepository commentQueryRepository;
     private final MonsterRepository monsterRepository;
+    private final JPAQueryFactory queryFactory;
 
     public MyPageReadRepositoryImpl(
             PostQueryRepository postQueryRepository,
             CommentQueryRepository commentQueryRepository,
-            MonsterRepository monsterRepository) {
+            MonsterRepository monsterRepository,
+            JPAQueryFactory queryFactory) {
         this.postQueryRepository = postQueryRepository;
         this.commentQueryRepository = commentQueryRepository;
         this.monsterRepository = monsterRepository;
+        this.queryFactory = queryFactory;
     }
 
     @Override
@@ -38,6 +47,27 @@ public class MyPageReadRepositoryImpl implements MyPageReadRepository {
     }
 
     @Override
+    public List<PostLike> findLikedPosts(User user, Long cursor, int size) {
+        QPostLike postLike = QPostLike.postLike;
+        QPost post = QPost.post;
+        QUser queryUser = QUser.user;
+
+        return queryFactory
+                .selectFrom(postLike)
+                .join(postLike.post, post)
+                .fetchJoin()
+                .join(post.user, queryUser)
+                .fetchJoin()
+                .where(
+                        postLike.user.eq(user),
+                        post.isDeleted.isFalse(),
+                        ltPostLikeId(postLike, cursor))
+                .orderBy(postLike.id.desc())
+                .limit(size + 1L)
+                .fetch();
+    }
+
+    @Override
     public List<Monster> findMonstersByPostIds(List<Long> postIds) {
         return postIds.isEmpty() ? List.of() : monsterRepository.findByPost_IdIn(postIds);
     }
@@ -45,5 +75,9 @@ public class MyPageReadRepositoryImpl implements MyPageReadRepository {
     @Override
     public List<Monster> findMonstersByUserId(Long userId) {
         return monsterRepository.findByPost_UserIdAndPost_IsDeletedFalse(userId);
+    }
+
+    private BooleanExpression ltPostLikeId(QPostLike postLike, Long cursor) {
+        return cursor != null ? postLike.id.lt(cursor) : null;
     }
 }

--- a/src/main/java/com/ddd/webbb/mypage/interfaces/MyPageController.java
+++ b/src/main/java/com/ddd/webbb/mypage/interfaces/MyPageController.java
@@ -5,6 +5,7 @@ import com.ddd.webbb.global.security.CustomUserPrincipal;
 import com.ddd.webbb.mypage.application.MyPageService;
 import com.ddd.webbb.mypage.interfaces.dto.MonsterStatsResponse;
 import com.ddd.webbb.mypage.interfaces.dto.MyCommentResponse;
+import com.ddd.webbb.mypage.interfaces.dto.MyLikedPostResponse;
 import com.ddd.webbb.mypage.interfaces.dto.MyPostResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,7 +28,24 @@ public class MyPageController {
 
     private final MyPageService myPageService;
 
-    @Operation(summary = "내가 작성한 게시글 목록 조회")
+    @Operation(
+            summary = "내가 작성한 게시글 목록 조회",
+            description =
+                    "로그인한 사용자가 작성한 게시글 목록을 최신순으로 반환합니다.\n\n"
+                            + "**emotionType** — 게시글에 생성된 몬스터의 감정 유형\n"
+                            + "- `ANXIETY`: 불안\n"
+                            + "- `LETHARGY`: 무기력\n"
+                            + "- `LONELINESS`: 외로움\n"
+                            + "- `SELF_DEPRECATION`: 자기비하\n"
+                            + "- `IRRITATION`: 짜증\n"
+                            + "- `null`: 몬스터가 아직 생성되지 않은 경우\n\n"
+                            + "**monsterStatus** — 몬스터의 현재 상태\n"
+                            + "- `ALIVE`: 몬스터가 살아있음 (HP > 0)\n"
+                            + "- `DEAD`: 공감·댓글로 HP가 0이 되어 처치됨\n"
+                            + "- `null`: 몬스터가 아직 생성되지 않은 경우\n\n"
+                            + "**커서 페이지네이션**: `nextCursor`가 null이면 마지막 페이지입니다.\n"
+                            + "다음 페이지 조회 시 `cursor` 파라미터에 `nextCursor` 값을 전달하세요.\n\n"
+                            + "인증 필요: Authorization 헤더에 Bearer Access Token을 포함해야 합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -64,6 +82,72 @@ public class MyPageController {
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
         MyPostResponse response = myPageService.getMyPosts(principal.publicId(), cursor, size);
         return ApiResponse.ok("내 게시글 목록을 조회했습니다.", response);
+    }
+
+    @Operation(
+            summary = "내가 공감한 게시글 목록 조회",
+            description =
+                    "로그인한 사용자가 공감(좋아요)한 게시글 목록을 최근 공감 순으로 반환합니다.\n\n"
+                            + "**emotionType** — 게시글에 생성된 몬스터의 감정 유형\n"
+                            + "- `ANXIETY`: 불안\n"
+                            + "- `LETHARGY`: 무기력\n"
+                            + "- `LONELINESS`: 외로움\n"
+                            + "- `SELF_DEPRECATION`: 자기비하\n"
+                            + "- `IRRITATION`: 짜증\n"
+                            + "- `null`: 몬스터가 아직 생성되지 않은 경우\n\n"
+                            + "**monsterStatus** — 몬스터의 현재 상태\n"
+                            + "- `ALIVE`: 몬스터가 살아있음 (HP > 0)\n"
+                            + "- `DEAD`: 공감·댓글로 HP가 0이 되어 처치됨\n"
+                            + "- `null`: 몬스터가 아직 생성되지 않은 경우\n\n"
+                            + "**커서 페이지네이션**: `nextCursor`가 null이면 마지막 페이지입니다.\n"
+                            + "다음 페이지 조회 시 `cursor` 파라미터에 `nextCursor` 값을 전달하세요.\n\n"
+                            + "인증 필요: Authorization 헤더에 Bearer Access Token을 포함해야 합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "공감한 게시글 목록 조회 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "공감한 게시글 목록을 조회했습니다.",
+                          "data": {
+                            "posts": [
+                              {
+                                "postId": 1,
+                                "contentPreview": "이직 준비 시작하는 게 진짜 힘들다...",
+                                "authorNickname": "오오",
+                                "authorJobType": "개발",
+                                "authorCareerLevel": "1년차",
+                                "emotionType": "LETHARGY",
+                                "monsterStatus": "ALIVE",
+                                "currentHp": 20,
+                                "maxHp": 30,
+                                "likeCount": 4,
+                                "commentCount": 4,
+                                "commentTone": "COMFORT_ME",
+                                "createdAt": "2026-06-22T12:00:00"
+                              }
+                            ],
+                            "nextCursor": 42
+                          },
+                          "timestamp": "2026-06-23T10:00:00"
+                        }
+                        """)))
+    })
+    @GetMapping("/liked-posts")
+    public ApiResponse<MyLikedPostResponse> getMyLikedPosts(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Parameter(description = "커서 (마지막 postLikeId)") @RequestParam(required = false)
+                    Long cursor,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
+        MyLikedPostResponse response =
+                myPageService.getLikedPosts(principal.publicId(), cursor, size);
+        return ApiResponse.ok("공감한 게시글 목록을 조회했습니다.", response);
     }
 
     @Operation(summary = "내가 작성한 댓글 목록 조회")

--- a/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MyLikedPostResponse.java
+++ b/src/main/java/com/ddd/webbb/mypage/interfaces/dto/MyLikedPostResponse.java
@@ -1,0 +1,49 @@
+package com.ddd.webbb.mypage.interfaces.dto;
+
+import com.ddd.webbb.monster.domain.Monster;
+import com.ddd.webbb.post.domain.Post;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MyLikedPostResponse(List<LikedPost> posts, Long nextCursor) {
+
+    private static final int CONTENT_PREVIEW_LENGTH = 30;
+
+    public record LikedPost(
+            Long postId,
+            String contentPreview,
+            String authorNickname,
+            String authorJobType,
+            String authorCareerLevel,
+            String emotionType,
+            String monsterStatus,
+            int currentHp,
+            int maxHp,
+            int likeCount,
+            int commentCount,
+            String commentTone,
+            LocalDateTime createdAt) {
+
+        public static LikedPost of(Post post, Monster monster) {
+            String content = post.getContent() == null ? "" : post.getContent();
+            String preview =
+                    content.length() <= CONTENT_PREVIEW_LENGTH
+                            ? content
+                            : content.substring(0, CONTENT_PREVIEW_LENGTH) + "...";
+            return new LikedPost(
+                    post.getId(),
+                    preview,
+                    post.getUser().getNickname(),
+                    post.getUser().getJobType(),
+                    post.getUser().getCareerLevel(),
+                    monster != null ? monster.getEmotionType().name() : null,
+                    monster != null ? monster.getStatus().name() : null,
+                    monster != null ? monster.getHp() : 0,
+                    monster != null ? monster.getMaxHp() : 0,
+                    post.getLikeCount(),
+                    post.getCommentCount(),
+                    post.getCommentTone().name(),
+                    post.getCreatedAt());
+        }
+    }
+}

--- a/src/test/java/com/ddd/webbb/mypage/application/MyPageServiceTest.java
+++ b/src/test/java/com/ddd/webbb/mypage/application/MyPageServiceTest.java
@@ -15,9 +15,11 @@ import com.ddd.webbb.monster.domain.Monster;
 import com.ddd.webbb.mypage.domain.MyPageReadRepository;
 import com.ddd.webbb.mypage.interfaces.dto.MonsterStatsResponse;
 import com.ddd.webbb.mypage.interfaces.dto.MyCommentResponse;
+import com.ddd.webbb.mypage.interfaces.dto.MyLikedPostResponse;
 import com.ddd.webbb.mypage.interfaces.dto.MyPostResponse;
 import com.ddd.webbb.post.domain.CommentTone;
 import com.ddd.webbb.post.domain.Post;
+import com.ddd.webbb.post.domain.PostLike;
 import com.ddd.webbb.user.application.UserService;
 import com.ddd.webbb.user.domain.User;
 import java.time.LocalDateTime;
@@ -125,6 +127,104 @@ class MyPageServiceTest {
         assertThat(response.comments()).hasSize(1);
         assertThat(response.comments().get(0).commentId()).isEqualTo(2L);
         assertThat(response.nextCursor()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("공감한 글 목록은 공감 순(postLike.id 내림차순)으로 nextCursor를 계산한다")
+    void likedPosts_returnsNextCursorWhenHasNext() {
+        Post postA =
+                Post.create(user, post.getCategory(), "titleA", "첫 번째 글", CommentTone.COMFORT_ME);
+        ReflectionTestUtils.setField(postA, "id", 10L);
+        ReflectionTestUtils.setField(postA, "createdAt", LocalDateTime.of(2026, 6, 20, 10, 0));
+
+        Post postB =
+                Post.create(user, post.getCategory(), "titleB", "두 번째 글", CommentTone.VENT_WITH_ME);
+        ReflectionTestUtils.setField(postB, "id", 11L);
+        ReflectionTestUtils.setField(postB, "createdAt", LocalDateTime.of(2026, 6, 21, 10, 0));
+
+        PostLike likeA = PostLike.create(postA, user);
+        ReflectionTestUtils.setField(likeA, "id", 2L);
+
+        PostLike likeB = PostLike.create(postB, user);
+        ReflectionTestUtils.setField(likeB, "id", 1L);
+
+        Monster monsterA = Monster.create(postA, EmotionType.LETHARGY, 30);
+        ReflectionTestUtils.setField(monsterA, "hp", 20);
+
+        given(userService.getUserEntity(any(UUID.class))).willReturn(user);
+        given(myPageReadRepository.findLikedPosts(user, null, 1)).willReturn(List.of(likeA, likeB));
+        given(myPageReadRepository.findMonstersByPostIds(List.of(10L)))
+                .willReturn(List.of(monsterA));
+
+        MyLikedPostResponse response = myPageService.getLikedPosts(UUID.randomUUID(), null, 1);
+
+        assertThat(response.posts()).hasSize(1);
+        assertThat(response.posts().get(0).postId()).isEqualTo(10L);
+        assertThat(response.nextCursor()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("공감한 글이 마지막 페이지면 nextCursor가 null이다")
+    void likedPosts_returnsNullCursorOnLastPage() {
+        Post postA =
+                Post.create(user, post.getCategory(), "titleA", "유일한 글", CommentTone.COMFORT_ME);
+        ReflectionTestUtils.setField(postA, "id", 10L);
+        ReflectionTestUtils.setField(postA, "createdAt", LocalDateTime.of(2026, 6, 20, 10, 0));
+
+        PostLike likeA = PostLike.create(postA, user);
+        ReflectionTestUtils.setField(likeA, "id", 1L);
+
+        given(userService.getUserEntity(any(UUID.class))).willReturn(user);
+        given(myPageReadRepository.findLikedPosts(user, null, 20)).willReturn(List.of(likeA));
+        given(myPageReadRepository.findMonstersByPostIds(List.of(10L))).willReturn(List.of());
+
+        MyLikedPostResponse response = myPageService.getLikedPosts(UUID.randomUUID(), null, 20);
+
+        assertThat(response.posts()).hasSize(1);
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("공감한 글 DTO에 작성자 정보와 몬스터 HP가 포함된다")
+    void likedPosts_includesAuthorAndMonsterFields() {
+        ReflectionTestUtils.setField(user, "nickname", "오오");
+        ReflectionTestUtils.setField(user, "jobType", "개발");
+        ReflectionTestUtils.setField(user, "careerLevel", "1년차");
+
+        Post postA =
+                Post.create(
+                        user,
+                        post.getCategory(),
+                        "titleA",
+                        "내용 미리보기 테스트 글입니다",
+                        CommentTone.COMFORT_ME);
+        ReflectionTestUtils.setField(postA, "id", 10L);
+        ReflectionTestUtils.setField(postA, "likeCount", 4);
+        ReflectionTestUtils.setField(postA, "commentCount", 3);
+        ReflectionTestUtils.setField(postA, "createdAt", LocalDateTime.of(2026, 6, 20, 10, 0));
+
+        PostLike likeA = PostLike.create(postA, user);
+        ReflectionTestUtils.setField(likeA, "id", 1L);
+
+        Monster monster = Monster.create(postA, EmotionType.LETHARGY, 30);
+        ReflectionTestUtils.setField(monster, "hp", 20);
+
+        given(userService.getUserEntity(any(UUID.class))).willReturn(user);
+        given(myPageReadRepository.findLikedPosts(user, null, 20)).willReturn(List.of(likeA));
+        given(myPageReadRepository.findMonstersByPostIds(List.of(10L)))
+                .willReturn(List.of(monster));
+
+        MyLikedPostResponse response = myPageService.getLikedPosts(UUID.randomUUID(), null, 20);
+
+        MyLikedPostResponse.LikedPost likedPost = response.posts().get(0);
+        assertThat(likedPost.authorNickname()).isEqualTo("오오");
+        assertThat(likedPost.authorJobType()).isEqualTo("개발");
+        assertThat(likedPost.authorCareerLevel()).isEqualTo("1년차");
+        assertThat(likedPost.emotionType()).isEqualTo("LETHARGY");
+        assertThat(likedPost.currentHp()).isEqualTo(20);
+        assertThat(likedPost.maxHp()).isEqualTo(30);
+        assertThat(likedPost.likeCount()).isEqualTo(4);
+        assertThat(likedPost.commentTone()).isEqualTo("COMFORT_ME");
     }
 
     @Test

--- a/src/test/java/com/ddd/webbb/mypage/interfaces/MyPageControllerTest.java
+++ b/src/test/java/com/ddd/webbb/mypage/interfaces/MyPageControllerTest.java
@@ -1,6 +1,7 @@
 package com.ddd.webbb.mypage.interfaces;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,7 +19,9 @@ import com.ddd.webbb.global.config.SecurityConfig;
 import com.ddd.webbb.global.security.CustomUserPrincipal;
 import com.ddd.webbb.mypage.application.MyPageService;
 import com.ddd.webbb.mypage.interfaces.dto.MonsterStatsResponse;
+import com.ddd.webbb.mypage.interfaces.dto.MyLikedPostResponse;
 import com.ddd.webbb.user.application.UserService;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -76,6 +79,54 @@ class MyPageControllerTest {
     @DisplayName("인증 없이 조회하면 401을 반환한다")
     void unauthenticatedRequest_returns401() throws Exception {
         mockMvc.perform(get("/api/me/monster-stats"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 공감한 게시글 목록을 조회한다")
+    void authenticatedUser_getsLikedPosts() throws Exception {
+        UUID userId = UUID.randomUUID();
+        CustomUserPrincipal principal = new CustomUserPrincipal(userId, "ogu@test.com", "오구");
+
+        MyLikedPostResponse.LikedPost likedPost =
+                new MyLikedPostResponse.LikedPost(
+                        1L,
+                        "이직 준비 시작하는 게 진짜...",
+                        "오오",
+                        "개발",
+                        "1년차",
+                        "LETHARGY",
+                        "ALIVE",
+                        20,
+                        30,
+                        4,
+                        4,
+                        "COMFORT_ME",
+                        LocalDateTime.of(2026, 6, 22, 12, 0));
+        MyLikedPostResponse response = new MyLikedPostResponse(List.of(likedPost), null);
+        given(myPageService.getLikedPosts(any(UUID.class), any(), anyInt())).willReturn(response);
+
+        mockMvc.perform(
+                        get("/api/me/liked-posts")
+                                .with(
+                                        authentication(
+                                                new UsernamePasswordAuthenticationToken(
+                                                        principal, null, List.of()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.posts[0].postId").value(1))
+                .andExpect(jsonPath("$.data.posts[0].authorNickname").value("오오"))
+                .andExpect(jsonPath("$.data.posts[0].emotionType").value("LETHARGY"))
+                .andExpect(jsonPath("$.data.posts[0].currentHp").value(20))
+                .andExpect(jsonPath("$.data.posts[0].maxHp").value(30))
+                .andExpect(jsonPath("$.data.nextCursor").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("인증 없이 공감한 글을 조회하면 401을 반환한다")
+    void unauthenticatedLikedPosts_returns401() throws Exception {
+        mockMvc.perform(get("/api/me/liked-posts"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.success").value(false));
     }


### PR DESCRIPTION
## PR 제목(내용 요약)
마이페이지 공감한 글 목록 조회 API 추가 (`GET /api/me/liked-posts`)

## 📌 변경 내용 & 이유
마이페이지에 작성글/작성댓글 탭은 있었지만 **공감한 글 탭에 대응하는 API가 없었습니다.**
프론트엔드 마이페이지 구현을 위해 신규 엔드포인트를 추가했습니다.

- `GET /api/me/liked-posts` 엔드포인트 추가
- `postLike.id` 기준 커서 페이지네이션 (최근 공감 순 내림차순)
  - `post.id` 대신 `postLike.id`를 커서로 사용한 이유: 오래된 글을 나중에 공감할 경우 post.id 순서와 공감 순서가 달라지기 때문
- `postLike → post → user` fetchJoin으로 N+1 방지, 몬스터는 기존 배치 in-query 패턴 재사용 (총 쿼리 2회)
- `emotionType`, `monsterStatus` 값 설명을 `/api/me/posts`, `/api/me/liked-posts` Swagger 문서에 추가
- DB 스키마 변경 없음 (`post_like` 테이블 기존 사용)

## 🧪 테스트 방법
- `MyPageServiceTest`: 커서 페이지네이션, 마지막 페이지 null cursor, 작성자·몬스터 필드 포함 여부
- `MyPageControllerTest`: 200 해피케이스, 인증 없이 401

```
./gradlew :test --tests "com.ddd.webbb.mypage.*"
```

## 📢 논의하고 싶은 내용
없음

## ✅ 체크리스트
- [x] 엔티티(`@Entity`) 스키마를 변경한 경우 `db/migration/V{N}__*.sql` 파일을 함께 포함했다
  - 해당 없음 (스키마 변경 없음)

## 🧩 관련 이슈
Closes #106