### PR TITLE
feat(auth): 비밀번호 찾기 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ dependencies {
     // AOP (Resilience4j 어노테이션 동작에 필요)
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+    // Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     // Micrometer Prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
 

--- a/src/main/java/com/ddd/webbb/ai/interfaces/AiTestController.java
+++ b/src/main/java/com/ddd/webbb/ai/interfaces/AiTestController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/ai/test")
 @Tag(name = "AI Test", description = "AI 감정 분석 / 댓글 요약 테스트 API")
+@Profile("ai-test")
 public class AiTestController {
 
     private final AiAnalysisService aiAnalysisService;

--- a/src/main/java/com/ddd/webbb/auth/application/AuthService.java
+++ b/src/main/java/com/ddd/webbb/auth/application/AuthService.java
@@ -3,6 +3,8 @@ package com.ddd.webbb.auth.application;
 import com.ddd.webbb.auth.domain.AuthToken;
 import com.ddd.webbb.auth.infrastructure.OAuthClient;
 import com.ddd.webbb.auth.infrastructure.OAuthUserInfo;
+import com.ddd.webbb.auth.infrastructure.PasswordResetEmailSender;
+import com.ddd.webbb.auth.infrastructure.PasswordResetStore;
 import com.ddd.webbb.auth.infrastructure.RefreshTokenStore;
 import com.ddd.webbb.auth.interfaces.dto.AuthResponse;
 import com.ddd.webbb.auth.interfaces.dto.AuthResponse.TokenInfo;
@@ -18,6 +20,7 @@ import com.ddd.webbb.user.domain.User;
 import com.ddd.webbb.user.domain.UserOauth;
 import com.ddd.webbb.user.domain.UserOauthRepository;
 import com.ddd.webbb.user.domain.UserRepository;
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,6 +40,8 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
     private final RefreshTokenStore refreshTokenStore;
+    private final PasswordResetStore passwordResetStore;
+    private final PasswordResetEmailSender passwordResetEmailSender;
     private final Map<OAuthProvider, OAuthClient> oauthClients;
 
     public AuthService(
@@ -45,12 +50,16 @@ public class AuthService {
             JwtProvider jwtProvider,
             PasswordEncoder passwordEncoder,
             RefreshTokenStore refreshTokenStore,
+            PasswordResetStore passwordResetStore,
+            PasswordResetEmailSender passwordResetEmailSender,
             List<OAuthClient> oauthClientList) {
         this.userRepository = userRepository;
         this.userOauthRepository = userOauthRepository;
         this.jwtProvider = jwtProvider;
         this.passwordEncoder = passwordEncoder;
         this.refreshTokenStore = refreshTokenStore;
+        this.passwordResetStore = passwordResetStore;
+        this.passwordResetEmailSender = passwordResetEmailSender;
         this.oauthClients =
                 oauthClientList.stream()
                         .collect(Collectors.toMap(OAuthClient::getProvider, Function.identity()));
@@ -250,6 +259,39 @@ public class AuthService {
 
     public void logout(UUID publicId) {
         refreshTokenStore.delete(publicId);
+    }
+
+    public void requestPasswordReset(String email) {
+        Optional<User> userOpt = userRepository.findByEmailAndDeletedAtIsNull(email);
+        if (userOpt.isEmpty()) {
+            return;
+        }
+
+        User user = userOpt.get();
+        if (user.getPasswordHash() == null) {
+            throw new AppException(ErrorCode.NO_PASSWORD_ACCOUNT);
+        }
+
+        String code = generateOtp();
+        passwordResetStore.save(email, code);
+        passwordResetEmailSender.send(email, code);
+    }
+
+    @Transactional
+    public void confirmPasswordReset(String email, String code, String newPassword) {
+        if (!passwordResetStore.verifyAndDelete(email, code)) {
+            throw new AppException(ErrorCode.INVALID_RESET_CODE);
+        }
+
+        User user =
+                userRepository
+                        .findByEmailAndDeletedAtIsNull(email)
+                        .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+        user.updatePassword(passwordEncoder.encode(newPassword));
+    }
+
+    private String generateOtp() {
+        return String.format("%06d", new SecureRandom().nextInt(1_000_000));
     }
 
     private void validateOAuthUserInfo(OAuthUserInfo oauthUserInfo) {

--- a/src/main/java/com/ddd/webbb/auth/infrastructure/PasswordResetEmailSender.java
+++ b/src/main/java/com/ddd/webbb/auth/infrastructure/PasswordResetEmailSender.java
@@ -1,0 +1,37 @@
+package com.ddd.webbb.auth.infrastructure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordResetEmailSender {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String from;
+
+    public PasswordResetEmailSender(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void send(String to, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(from);
+        message.setTo(to);
+        message.setSubject("[WEBBB] 비밀번호 재설정 인증 코드");
+        message.setText(
+                """
+                안녕하세요.
+
+                비밀번호 재설정 인증 코드: %s
+
+                이 코드는 5분간 유효합니다.
+                본인이 요청하지 않은 경우 이 메일을 무시해 주세요.
+                """
+                        .formatted(code));
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/ddd/webbb/auth/infrastructure/PasswordResetEmailSender.java
+++ b/src/main/java/com/ddd/webbb/auth/infrastructure/PasswordResetEmailSender.java
@@ -21,7 +21,7 @@ public class PasswordResetEmailSender {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setFrom(from);
         message.setTo(to);
-        message.setSubject("[WEBBB] 비밀번호 재설정 인증 코드");
+        message.setSubject("[오구오구] 비밀번호 재설정 인증 코드");
         message.setText(
                 """
                 안녕하세요.

--- a/src/main/java/com/ddd/webbb/auth/infrastructure/PasswordResetStore.java
+++ b/src/main/java/com/ddd/webbb/auth/infrastructure/PasswordResetStore.java
@@ -1,0 +1,31 @@
+package com.ddd.webbb.auth.infrastructure;
+
+import java.util.concurrent.TimeUnit;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordResetStore {
+
+    private static final String KEY_PREFIX = "password_reset:";
+    private static final long TTL_SECONDS = 300L;
+
+    private final StringRedisTemplate redisTemplate;
+
+    public PasswordResetStore(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(String email, String code) {
+        redisTemplate.opsForValue().set(KEY_PREFIX + email, code, TTL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    public boolean verifyAndDelete(String email, String code) {
+        String stored = redisTemplate.opsForValue().get(KEY_PREFIX + email);
+        if (stored == null || !stored.equals(code)) {
+            return false;
+        }
+        redisTemplate.delete(KEY_PREFIX + email);
+        return true;
+    }
+}

--- a/src/main/java/com/ddd/webbb/auth/interfaces/AuthController.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/AuthController.java
@@ -10,6 +10,8 @@ import com.ddd.webbb.auth.interfaces.dto.EmailSignupRequest;
 import com.ddd.webbb.auth.interfaces.dto.OAuthCodeExchangeRequest;
 import com.ddd.webbb.auth.interfaces.dto.OAuthLinkRequest;
 import com.ddd.webbb.auth.interfaces.dto.OAuthLoginRequest;
+import com.ddd.webbb.auth.interfaces.dto.PasswordResetConfirmRequest;
+import com.ddd.webbb.auth.interfaces.dto.PasswordResetRequest;
 import com.ddd.webbb.global.common.exception.AppException;
 import com.ddd.webbb.global.common.exception.ErrorCode;
 import com.ddd.webbb.global.common.response.ApiResponse;
@@ -516,6 +518,88 @@ public class AuthController {
         UUID publicId = UUID.fromString(principal.getName());
         authService.linkOAuth(publicId, provider, request.oauthAccessToken());
         return ApiResponse.ok("OAuth 계정이 연동되었습니다.", null);
+    }
+
+    @Operation(summary = "비밀번호 재설정 코드 요청")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "코드 발송 성공 (미가입 이메일도 동일 응답)",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "입력하신 이메일로 인증 코드를 발송했습니다.",
+                          "data": null,
+                          "timestamp": "2026-06-29T12:00:00"
+                        }
+                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "소셜 로그인 전용 계정",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": false,
+                          "message": "소셜 로그인으로 가입된 계정입니다. Google/Kakao/Naver 로그인을 이용해 주세요.",
+                          "timestamp": "2026-06-29T12:00:00"
+                        }
+                        """)))
+    })
+    @PostMapping("/password-reset/request")
+    public ApiResponse<Void> requestPasswordReset(
+            @RequestBody @Valid PasswordResetRequest request) {
+        authService.requestPasswordReset(request.email());
+        return ApiResponse.ok("입력하신 이메일로 인증 코드를 발송했습니다.", null);
+    }
+
+    @Operation(summary = "비밀번호 재설정 확인")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "비밀번호 변경 성공",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": true,
+                          "message": "비밀번호가 변경됐습니다.",
+                          "data": null,
+                          "timestamp": "2026-06-29T12:00:00"
+                        }
+                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "인증 코드 불일치 또는 만료",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                        {
+                          "success": false,
+                          "message": "인증 코드가 유효하지 않거나 만료됐습니다.",
+                          "timestamp": "2026-06-29T12:00:00"
+                        }
+                        """)))
+    })
+    @PostMapping("/password-reset/confirm")
+    public ApiResponse<Void> confirmPasswordReset(
+            @RequestBody @Valid PasswordResetConfirmRequest request) {
+        authService.confirmPasswordReset(request.email(), request.code(), request.newPassword());
+        return ApiResponse.ok("비밀번호가 변경됐습니다.", null);
     }
 
     @Operation(summary = "OAuth 계정 연동 해제")

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/PasswordResetConfirmRequest.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/PasswordResetConfirmRequest.java
@@ -1,0 +1,13 @@
+package com.ddd.webbb.auth.interfaces.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PasswordResetConfirmRequest(
+        @NotBlank(message = "이메일은 필수입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+        @NotBlank(message = "인증 코드는 필수입니다.") @Size(min = 6, max = 6, message = "인증 코드는 6자리입니다.")
+                String code,
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+                @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
+                String newPassword) {}

--- a/src/main/java/com/ddd/webbb/auth/interfaces/dto/PasswordResetRequest.java
+++ b/src/main/java/com/ddd/webbb/auth/interfaces/dto/PasswordResetRequest.java
@@ -1,0 +1,7 @@
+package com.ddd.webbb.auth.interfaces.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordResetRequest(
+        @NotBlank(message = "이메일은 필수입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email) {}

--- a/src/main/java/com/ddd/webbb/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/ddd/webbb/global/common/exception/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
     OAUTH_ALREADY_LINKED(HttpStatus.CONFLICT, "해당 OAuth 계정은 다른 사용자에게 이미 연동되어 있습니다."),
     OAUTH_PROVIDER_NOT_LINKED(HttpStatus.NOT_FOUND, "해당 OAuth 제공자가 연동되어 있지 않습니다."),
     CANNOT_UNLINK_LAST_AUTH(HttpStatus.BAD_REQUEST, "마지막 인증 수단은 해제할 수 없습니다."),
+    INVALID_RESET_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 유효하지 않거나 만료됐습니다."),
+    NO_PASSWORD_ACCOUNT(
+            HttpStatus.BAD_REQUEST, "소셜 로그인으로 가입된 계정입니다. Google/Kakao/Naver 로그인을 이용해 주세요."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/com/ddd/webbb/global/config/SecurityConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SecurityConfig.java
@@ -79,7 +79,9 @@ public class SecurityConfig {
                                                 "/api/auth/email/check",
                                                 "/api/auth/login/email",
                                                 "/api/auth/oauth/**",
-                                                "/api/auth/refresh")
+                                                "/api/auth/refresh",
+                                                "/api/auth/password-reset/request",
+                                                "/api/auth/password-reset/confirm")
                                         .permitAll()
                                         // /api/users/me 는 인증 필요 (wildcard 보다 먼저 선언)
                                         .requestMatchers("/api/users/me")

--- a/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ddd/webbb/global/config/SwaggerConfig.java
@@ -146,6 +146,8 @@ public class SwaggerConfig {
         put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/auth/refresh");
         put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/auth/link/{provider}");
         put(statuses, ApiImplementationStatus.LIVE, "DELETE", "/api/auth/link/{provider}");
+        put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/auth/password-reset/request");
+        put(statuses, ApiImplementationStatus.LIVE, "POST", "/api/auth/password-reset/confirm");
 
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/users/nickname/check");
         put(statuses, ApiImplementationStatus.LIVE, "GET", "/api/users/me");

--- a/src/main/java/com/ddd/webbb/user/domain/User.java
+++ b/src/main/java/com/ddd/webbb/user/domain/User.java
@@ -93,6 +93,10 @@ public class User extends BaseEntity {
         }
     }
 
+    public void updatePassword(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
     public void withdraw() {
         this.isActive = false;
         this.deletedAt = LocalDateTime.now();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,18 @@ spring:
     virtual:
       enabled: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/src/test/java/com/ddd/webbb/ai/interfaces/AiTestControllerProdProfileTest.java
+++ b/src/test/java/com/ddd/webbb/ai/interfaces/AiTestControllerProdProfileTest.java
@@ -1,14 +1,9 @@
 package com.ddd.webbb.ai.interfaces;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.ddd.webbb.ai.application.AiAnalysisResponse;
 import com.ddd.webbb.ai.application.AiAnalysisService;
-import com.ddd.webbb.ai.domain.PostContent;
 import com.ddd.webbb.comment.application.CommentSummaryService;
 import com.ddd.webbb.global.auth.JwtAuthFilter;
 import org.junit.jupiter.api.Test;
@@ -34,11 +29,7 @@ class AiTestControllerProdProfileTest {
     @MockitoBean private JwtAuthFilter jwtAuthFilter;
 
     @Test
-    void prod_프로필에서도_감정_분석_요청을_처리한다() throws Exception {
-        AiAnalysisResponse mockResponse =
-                new AiAnalysisResponse("ANXIETY", 30, 0.9, "불안 표현이 강함", false, "OPENAI");
-        given(aiAnalysisService.analyze(any(PostContent.class))).willReturn(mockResponse);
-
+    void prod_프로필에서는_ai_test_api를_사용할_수_없다() throws Exception {
         mockMvc.perform(
                         post("/api/ai/test/analyze")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -46,8 +37,6 @@ class AiTestControllerProdProfileTest {
                                         """
                     {"content": "프로덕션에서도 테스트하고 싶어요"}
                     """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.usedProvider").value("OPENAI"));
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/ddd/webbb/ai/interfaces/AiTestControllerTest.java
+++ b/src/test/java/com/ddd/webbb/ai/interfaces/AiTestControllerTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(AiTestController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("test")
+@ActiveProfiles("ai-test")
 class AiTestControllerTest {
 
     @Autowired private MockMvc mockMvc;


### PR DESCRIPTION
## PR 제목(내용 요약)
feat(auth): 비밀번호 찾기 API 구현

## 📌 변경 내용 & 이유

이메일 로그인 사용자가 비밀번호를 잊었을 때 재설정할 수단이 없었습니다.  
이메일로 6자리 OTP 코드를 발송하고 새 비밀번호로 재설정하는 2단계 API를 추가했습니다.

**비밀번호 찾기 API**
- `POST /api/auth/password-reset/request` — 이메일로 OTP 발송
  - 미가입 이메일도 200 반환 (이메일 존재 여부 비노출)
  - OAuth 전용 계정(passwordHash = null)은 400 반환
- `POST /api/auth/password-reset/confirm` — OTP 검증 후 비밀번호 변경
  - OTP 불일치/만료 시 400 반환
  - 성공 시 Redis에서 OTP 즉시 삭제 (재사용 방지)
- OTP는 Redis에 저장 (key: `password_reset:{email}`, TTL: 5분)
- Gmail SMTP + Spring Mail로 이메일 발송
- `SecurityConfig`에 두 엔드포인트 `permitAll` 추가

**AI 테스트 API 프로파일 분리** (함께 포함)
- `AiTestController`에 `@Profile("ai-test")` 적용 — prod 환경에서 테스트 API 비노출
- 관련 테스트 업데이트

## 🧪 테스트 방법

1. `MAIL_USERNAME`, `MAIL_PASSWORD` 환경변수 설정 후 서버 실행
2. 비밀번호로 가입된 계정 이메일로 요청
```bash
# OTP 발송
curl -X POST http://localhost:8080/api/auth/password-reset/request \
  -H "Content-Type: application/json" \
  -d '{"email": "test@example.com"}'

# 비밀번호 재설정
curl -X POST http://localhost:8080/api/auth/password-reset/confirm \
  -H "Content-Type: application/json" \
  -d '{"email": "test@example.com", "code": "123456", "newPassword": "newPw123!"}'
```

## 📢 논의하고 싶은 내용

- OTP 재발송 rate-limit은 현재 미구현입니다. 필요하다면 Redis 기반으로 추가할 수 있습니다.

## ✅ 체크리스트
- [ ] 엔티티(`@Entity`) 스키마를 변경한 경우 `db/migration/V{N}__*.sql` 파일을 함께 포함했다

> 스키마 변경 없음 — `passwordHash`는 기존에 nullable 컬럼으로 존재

## 🧩 관련 이슈
Closes #110